### PR TITLE
[Fix] Respect Zotero PDF handler preference in Spotlight opens

### DIFF
--- a/src/modules/spotlight/actions.ts
+++ b/src/modules/spotlight/actions.ts
@@ -24,9 +24,14 @@ export class ActionHandler {
     if (!attachment) {
       return;
     }
+    const mainWindow = Zotero.getMainWindow();
+    const pane = mainWindow?.ZoteroPane;
+    if (shouldUseExternalPdfHandler(attachment)) {
+      pane?.viewAttachment?.(attachmentID);
+      return;
+    }
     const existing = getExistingReader(attachmentID);
     if (existing) {
-      const mainWindow = Zotero.getMainWindow();
       if (existing.tabID && mainWindow?.Zotero_Tabs?.select) {
         mainWindow.Zotero_Tabs.select(existing.tabID);
       }
@@ -46,8 +51,6 @@ export class ActionHandler {
         );
       }
     }
-    const mainWindow = Zotero.getMainWindow();
-    const pane = mainWindow?.ZoteroPane;
     if (pane?.viewAttachment) {
       pane.viewAttachment(attachmentID);
     }
@@ -146,6 +149,14 @@ function isPdfAttachment(item: Zotero.Item): boolean {
   const contentType =
     candidate.attachmentContentType || candidate.attachmentMIMEType;
   return item.isAttachment() && contentType === "application/pdf";
+}
+
+function shouldUseExternalPdfHandler(item: Zotero.Item): boolean {
+  if (!isPdfAttachment(item)) {
+    return false;
+  }
+  const handler = String(Zotero.Prefs.get("fileHandler.pdf") || "").trim();
+  return handler.length > 0;
 }
 
 function getExistingReader(

--- a/src/modules/spotlight/commands.ts
+++ b/src/modules/spotlight/commands.ts
@@ -312,6 +312,10 @@ export class CommandRegistry {
           if (!attachmentID) {
             return;
           }
+          if (shouldUseExternalPdfHandler()) {
+            pane.viewAttachment?.(attachmentID);
+            return;
+          }
           if (typeof (Zotero as any).Reader?.open === "function") {
             await (Zotero as any).Reader.open(attachmentID, {
               openInWindow: false,
@@ -470,6 +474,11 @@ function isPDFAttachment(item: Zotero.Item): boolean {
   const contentType =
     candidate.attachmentContentType || candidate.attachmentMIMEType || "";
   return String(contentType).toLowerCase().includes("pdf");
+}
+
+function shouldUseExternalPdfHandler(): boolean {
+  const handler = String(Zotero.Prefs.get("fileHandler.pdf") || "").trim();
+  return handler.length > 0;
 }
 
 function getActiveTabItemID(win: Window): number | null {


### PR DESCRIPTION
## [Fix] Respect Zotero PDF handler preference in Spotlight opens

📋 What does this PR do?
Fixes an issue where opening PDFs from Spotlight would ignore the user's configured Zotero PDF handler preference.

