### PR TITLE
add epub/snapshot support and respect copy citation shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Spotlight is different:
 ## Features
 
 - Open Spotlight with one shortcut: `Cmd+P` on macOS, `Ctrl+P` on Windows/Linux.
-- Works in the main Zotero window, PDF reader, and note editor.
+- Works in the main Zotero window, reader, and note editor.
 
 ### 1. Search, Switch, Filter
 
@@ -42,7 +42,7 @@ Spotlight is different:
 
 ### 2. Commands and Workflows
 
-- Use `>` to enter command mode for built-in actions like `New Note`, `Copy Citation`, `Copy Bibliography`, `Open Collection`, and `Show PDF in Finder/Explorer`.
+- Use `>` to enter command mode for built-in actions like `New Note`, `Copy Citation`, `Copy Bibliography`, `Open Collection`, and `Show PDF/EPUB/Snapshot in Finder/Explorer`.
 - Run reusable workflows like `>literature note` and `>extract highlights` for common research tasks.
 - Use `>tabs` to search and switch across currently open Zotero tabs.
 - Trigger context-aware commands based on the current Zotero window and selected item.

--- a/addon/content/preferences.xhtml
+++ b/addon/content/preferences.xhtml
@@ -33,6 +33,7 @@
     <vbox
       id="zotero-prefpane-__addonRef__-shortcut"
       class="zotero-spotlight-radio-group"
+      orient="horizontal"
     >
       <html:label class="zotero-spotlight-radio-option">
         <html:input
@@ -69,6 +70,8 @@
         id="zotero-prefpane-__addonRef__-results-limit"
         min="5"
         max="40"
+        step="1"
+        style="min-width: 50px"
       ></html:input>
     </hbox>
   </vbox>
@@ -87,6 +90,8 @@
         id="zotero-prefpane-__addonRef__-window-height"
         min="200"
         max="800"
+        step="10"
+        style="min-width: 50px"
       ></html:input>
     </hbox>
     <hbox align="center" pack="start">
@@ -99,6 +104,8 @@
         id="zotero-prefpane-__addonRef__-window-width"
         min="300"
         max="1200"
+        step="10"
+        style="min-width: 60px"
       ></html:input>
     </hbox>
   </vbox>

--- a/addon/locale/en-US/preferences.ftl
+++ b/addon/locale/en-US/preferences.ftl
@@ -4,7 +4,7 @@ pref-shortcut-primary = { PLATFORM() ->
        *[other] Ctrl+P
     }
 pref-shortcut-fallback = { PLATFORM() ->
-        [macos] ⌘+Shift+P
+        [macos] ⌘+⇧+P
        *[other] Ctrl+Shift+P
     }
 pref-results-section = Results

--- a/addon/locale/en-US/preferences.ftl
+++ b/addon/locale/en-US/preferences.ftl
@@ -1,6 +1,12 @@
 pref-shortcut-section = Shortcuts
-pref-shortcut-primary = Cmd+P (MacOS) or Ctrl+P (Windows/Linux)
-pref-shortcut-fallback = Cmd+Shift+P (MacOS) or Ctrl+Shift+P (Windows/Linux)
+pref-shortcut-primary = { PLATFORM() ->
+        [macos] ⌘+P
+       *[other] Ctrl+P
+    }
+pref-shortcut-fallback = { PLATFORM() ->
+        [macos] ⌘+Shift+P
+       *[other] Ctrl+Shift+P
+    }
 pref-results-section = Results
 pref-results-limit = Results limit
 

--- a/addon/locale/zh-CN/preferences.ftl
+++ b/addon/locale/zh-CN/preferences.ftl
@@ -1,6 +1,12 @@
 pref-shortcut-section = 快捷键
-pref-shortcut-primary = Cmd+P (MacOS) or Ctrl+P (Windows/Linux)
-pref-shortcut-fallback = Cmd+Shift+P (MacOS) or Ctrl+Shift+P (Windows/Linux)
+pref-shortcut-primary = { PLATFORM() ->
+        [macos] ⌘+P
+       *[other] Ctrl+P
+    }
+pref-shortcut-fallback = { PLATFORM() ->
+        [macos] ⌘+Shift+P
+       *[other] Ctrl+Shift+P
+    }
 pref-results-section = 结果限制
 pref-results-limit = 结果数量上限
 

--- a/addon/locale/zh-CN/preferences.ftl
+++ b/addon/locale/zh-CN/preferences.ftl
@@ -4,7 +4,7 @@ pref-shortcut-primary = { PLATFORM() ->
        *[other] Ctrl+P
     }
 pref-shortcut-fallback = { PLATFORM() ->
-        [macos] ⌘+Shift+P
+        [macos] ⌘+⇧+P
        *[other] Ctrl+Shift+P
     }
 pref-results-section = 结果限制

--- a/src/modules/spotlight/actions.ts
+++ b/src/modules/spotlight/actions.ts
@@ -1,4 +1,10 @@
 import type { QuickOpenResult } from "./search";
+import { getAttachmentResultType } from "./itemMetadata";
+import { shouldUseExternalHandler } from "./commands";
+import {
+  getBestOpenableAttachmentID,
+  isOpenableAttachment,
+} from "./attachmentHelpers";
 
 export type OpenIntent = "default" | "alternate" | "reveal";
 
@@ -35,7 +41,7 @@ export class ActionHandler {
     }
     if (
       alternate &&
-      isPdfAttachment(attachment) &&
+      isOpenableAttachment(attachment) &&
       typeof (Zotero as any).FileHandlers?.open === "function"
     ) {
       try {
@@ -52,7 +58,7 @@ export class ActionHandler {
     }
     const mainWindow = Zotero.getMainWindow();
     const pane = mainWindow?.ZoteroPane;
-    if (shouldUseExternalPdfHandler(attachment)) {
+    if (shouldUseExternalHandler(getAttachmentResultType(attachment))) {
       pane?.viewAttachment?.(attachmentID);
       return;
     }
@@ -164,52 +170,8 @@ export class ActionHandler {
     if (!item) {
       return null;
     }
-    const candidate = item as any;
-    if (typeof candidate.getBestAttachment === "function") {
-      const best = await candidate.getBestAttachment();
-      if (typeof best === "number") {
-        return best;
-      }
-      if (best?.id) {
-        return best.id as number;
-      }
-    }
-    if (typeof candidate.getPrimaryAttachment === "function") {
-      const primary = await candidate.getPrimaryAttachment();
-      if (typeof primary === "number") {
-        return primary;
-      }
-      if (primary?.id) {
-        return primary.id as number;
-      }
-    }
-    const attachmentIDs = candidate.getAttachments?.() || [];
-    for (const attachmentID of attachmentIDs) {
-      const attachment = Zotero.Items.get(attachmentID) as Zotero.Item;
-      if (attachment && isPdfAttachment(attachment)) {
-        return attachmentID;
-      }
-    }
-    return null;
+    return getBestOpenableAttachmentID(item);
   }
-}
-
-function isPdfAttachment(item: Zotero.Item): boolean {
-  const candidate = item as any;
-  if (typeof candidate.isPDFAttachment === "function") {
-    return candidate.isPDFAttachment();
-  }
-  const contentType =
-    candidate.attachmentContentType || candidate.attachmentMIMEType;
-  return item.isAttachment() && contentType === "application/pdf";
-}
-
-function shouldUseExternalPdfHandler(item: Zotero.Item): boolean {
-  if (!isPdfAttachment(item)) {
-    return false;
-  }
-  const handler = String(Zotero.Prefs.get("fileHandler.pdf") || "").trim();
-  return handler.length > 0;
 }
 
 function getExistingReader(

--- a/src/modules/spotlight/attachmentHelpers.ts
+++ b/src/modules/spotlight/attachmentHelpers.ts
@@ -1,0 +1,139 @@
+import {
+  getAttachmentResultType,
+  type AttachmentResultType,
+} from "./itemMetadata";
+
+const OPENABLE_ATTACHMENT_TYPE_ORDER = ["pdf", "epub", "snapshot"] as const;
+
+type OpenableAttachmentType = (typeof OPENABLE_ATTACHMENT_TYPE_ORDER)[number];
+
+function getAttachmentID(value: unknown): number | null {
+  if (typeof value === "number") {
+    return value;
+  }
+  const candidate = value as { id?: unknown };
+  return typeof candidate?.id === "number" ? candidate.id : null;
+}
+
+export function isOpenableAttachmentType(
+  type: AttachmentResultType | string,
+): type is OpenableAttachmentType {
+  return type === "pdf" || type === "epub" || type === "snapshot";
+}
+
+export function isOpenableAttachment(item: Zotero.Item): boolean {
+  return isOpenableAttachmentType(getAttachmentResultType(item));
+}
+
+export function getPreferredOpenableAttachmentResultType(
+  item: Zotero.Item,
+): OpenableAttachmentType | null {
+  const candidate = item as any;
+  const attachmentIDs = candidate.getAttachments?.() || [];
+  for (const targetType of OPENABLE_ATTACHMENT_TYPE_ORDER) {
+    for (const attachmentID of attachmentIDs) {
+      const attachment = Zotero.Items.get(attachmentID) as Zotero.Item | null;
+      if (!attachment?.isAttachment?.()) {
+        continue;
+      }
+      if (getAttachmentResultType(attachment) === targetType) {
+        return targetType;
+      }
+    }
+  }
+  return null;
+}
+
+export async function getBestOpenableAttachmentID(
+  item: Zotero.Item,
+): Promise<number | null> {
+  const candidate = item as any;
+  if (typeof candidate.getBestAttachment === "function") {
+    const bestID = getAttachmentID(await candidate.getBestAttachment());
+    if (bestID) {
+      const attachment = Zotero.Items.get(bestID) as Zotero.Item | null;
+      if (attachment && isOpenableAttachment(attachment)) {
+        return bestID;
+      }
+    }
+  }
+  if (typeof candidate.getPrimaryAttachment === "function") {
+    const primaryID = getAttachmentID(await candidate.getPrimaryAttachment());
+    if (primaryID) {
+      const attachment = Zotero.Items.get(primaryID) as Zotero.Item | null;
+      if (attachment && isOpenableAttachment(attachment)) {
+        return primaryID;
+      }
+    }
+  }
+  const attachmentIDs = candidate.getAttachments?.() || [];
+  const firstByType: Partial<Record<OpenableAttachmentType, number>> = {};
+  for (const attachmentID of attachmentIDs) {
+    const attachment = Zotero.Items.get(attachmentID) as Zotero.Item | null;
+    if (!attachment?.isAttachment?.()) {
+      continue;
+    }
+    const type = getAttachmentResultType(attachment);
+    if (!isOpenableAttachmentType(type)) {
+      continue;
+    }
+    if (typeof firstByType[type] !== "number") {
+      firstByType[type] = attachmentID;
+    }
+  }
+  for (const targetType of OPENABLE_ATTACHMENT_TYPE_ORDER) {
+    const selected = firstByType[targetType];
+    if (typeof selected === "number") {
+      return selected;
+    }
+  }
+  return null;
+}
+
+export function getParentItem(item: Zotero.Item): Zotero.Item | null {
+  const parentID = (item as any).parentID ?? (item as any).parentItemID;
+  if (typeof parentID === "number") {
+    return Zotero.Items.get(parentID) as Zotero.Item;
+  }
+  return null;
+}
+
+export function getAttachmentParentItem(item: Zotero.Item): Zotero.Item | null {
+  const directParent = getParentItem(item);
+  if (directParent) {
+    return directParent;
+  }
+  const topLevel = (item as any).topLevelItem as Zotero.Item | undefined;
+  if (topLevel && topLevel.id && topLevel.id !== item.id) {
+    return topLevel;
+  }
+  return null;
+}
+
+export function getParentForCommand(
+  item: Zotero.Item | null,
+): Zotero.Item | null {
+  if (!item) {
+    return null;
+  }
+  if (item.isRegularItem()) {
+    return item;
+  }
+  return getAttachmentParentItem(item) || item;
+}
+
+export function getAttachmentTypeMeta(type: AttachmentResultType): {
+  label: string;
+  itemType: string;
+} {
+  if (type === "pdf") {
+    return { label: "PDF", itemType: "attachmentPDF" };
+  }
+  if (type === "epub") {
+    return { label: "EPUB", itemType: "attachmentEPUB" };
+  }
+  if (type === "snapshot") {
+    return { label: "Snapshot", itemType: "attachmentSnapshot" };
+  }
+  return { label: "Attachment", itemType: "attachment" };
+}

--- a/src/modules/spotlight/commands.ts
+++ b/src/modules/spotlight/commands.ts
@@ -2,6 +2,12 @@ import {
   getAttachmentResultType,
   type AttachmentResultType,
 } from "./itemMetadata";
+import {
+  getBestOpenableAttachmentID,
+  getAttachmentTypeMeta,
+  getParentForCommand,
+  isOpenableAttachment,
+} from "./attachmentHelpers";
 
 export type CommandContext = "main" | "reader" | "note";
 
@@ -633,25 +639,6 @@ function getCollectionTarget(item: Zotero.Item | null): Zotero.Item | null {
   return getParentForCommand(item);
 }
 
-function getParentForCommand(item: Zotero.Item | null): Zotero.Item | null {
-  if (!item) {
-    return null;
-  }
-  if (item.isRegularItem()) {
-    return item;
-  }
-  const candidate = item as any;
-  const parentID = candidate.parentID ?? candidate.parentItemID;
-  if (typeof parentID === "number") {
-    return Zotero.Items.get(parentID) as Zotero.Item;
-  }
-  const topLevel = candidate.topLevelItem as Zotero.Item | undefined;
-  if (topLevel && topLevel.id && topLevel.id !== item.id) {
-    return topLevel;
-  }
-  return item;
-}
-
 function getFirstCollectionID(item: Zotero.Item): number | null {
   const collections = item.getCollections?.();
   if (!collections || !collections.length) {
@@ -687,28 +674,7 @@ async function getBestAttachmentID(item: Zotero.Item): Promise<number | null> {
 async function getBestRevealableAttachmentID(
   item: Zotero.Item,
 ): Promise<number | null> {
-  const candidate = item as any;
-  if (typeof candidate.getBestAttachment === "function") {
-    const best = await candidate.getBestAttachment();
-    if (typeof best === "number") {
-      const bestItem = Zotero.Items.get(best) as Zotero.Item;
-      return bestItem && isRevealableAttachment(bestItem) ? best : null;
-    }
-    if (best?.id) {
-      const bestItem = Zotero.Items.get(best.id) as Zotero.Item;
-      return bestItem && isRevealableAttachment(bestItem)
-        ? (best.id as number)
-        : null;
-    }
-  }
-  const attachmentIDs = candidate.getAttachments?.() || [];
-  for (const attachmentID of attachmentIDs) {
-    const attachment = Zotero.Items.get(attachmentID) as Zotero.Item;
-    if (attachment && isRevealableAttachment(attachment)) {
-      return attachmentID;
-    }
-  }
-  return null;
+  return getBestOpenableAttachmentID(item);
 }
 
 async function createChildNote(
@@ -780,12 +746,7 @@ function buildExtractHighlightsNoteContent(
 ): string {
   const title = escapeHTML(parent.getDisplayTitle?.() || "Untitled");
   const sourceType = getAttachmentResultType(attachment);
-  const sourceTypeLabel =
-    sourceType === "item"
-      ? "Attachment"
-      : sourceType === "snapshot"
-        ? "Snapshot"
-        : sourceType.toUpperCase();
+  const sourceTypeLabel = getAttachmentTypeMeta(sourceType).label;
   const annotations = [...(attachment.getAnnotations?.() || [])]
     .filter((annotation) => {
       const text = annotation.annotationText?.trim() || "";
@@ -833,16 +794,11 @@ function hasRevealableAttachment(item: Zotero.Item): boolean {
   const attachmentIDs = candidate.getAttachments?.() || [];
   for (const attachmentID of attachmentIDs) {
     const attachment = Zotero.Items.get(attachmentID) as Zotero.Item;
-    if (attachment && isRevealableAttachment(attachment)) {
+    if (attachment && isOpenableAttachment(attachment)) {
       return true;
     }
   }
   return false;
-}
-
-function isRevealableAttachment(item: Zotero.Item): boolean {
-  const type = getAttachmentResultType(item);
-  return type === "pdf" || type === "epub" || type === "snapshot";
 }
 
 async function revealAttachmentInFileManager(
@@ -862,7 +818,7 @@ async function revealAttachmentInFileManager(
   await Zotero.File.reveal(filePath);
 }
 
-function shouldUseExternalHandler(
+export function shouldUseExternalHandler(
   attachmentType: AttachmentResultType,
 ): boolean {
   const prefKey =

--- a/src/modules/spotlight/commands.ts
+++ b/src/modules/spotlight/commands.ts
@@ -1,3 +1,8 @@
+import {
+  getAttachmentResultType,
+  type AttachmentResultType,
+} from "./itemMetadata";
+
 export type CommandContext = "main" | "reader" | "note";
 
 export interface CommandResult {
@@ -226,7 +231,10 @@ export class CommandRegistry {
         subtitle: "Copy citation for selected/current item",
         keywords: ["quick copy", "reference", "cite", "clipboard"],
         contexts: ["main", "reader", "note"],
-        shortcut: "Shift+Cmd/Ctrl+A",
+        shortcut: getZoteroShortcut(
+          "keys.copySelectedItemCitationsToClipboard",
+          "A",
+        ),
         icon: "copy-citation",
         group: "Export",
         isAvailable: ({ pane, activeItem }) => {
@@ -271,7 +279,10 @@ export class CommandRegistry {
         subtitle: "Copy bibliography for selected/current item",
         keywords: ["quick copy", "reference", "bibliography", "clipboard"],
         contexts: ["main", "reader", "note"],
-        shortcut: "Shift+Cmd/Ctrl+C",
+        shortcut: getZoteroShortcut(
+          "keys.copySelectedItemsToClipboard",
+          "C",
+        ),
         icon: "copy-bibliography",
         group: "Export",
         isAvailable: ({ pane, activeItem }) => {
@@ -311,10 +322,20 @@ export class CommandRegistry {
         },
       },
       {
-        id: "note-and-open-pdf",
-        title: "Add Note + Open PDF",
-        subtitle: "Create note for current item and open its PDF",
-        keywords: ["workflow", "note", "pdf", "open", "focus"],
+        id: "note-and-open-best-attachment",
+        title: "Add Note + Open Best Attachment",
+        subtitle: "Create note for current item and open its best attachment",
+        keywords: [
+          "workflow",
+          "note",
+          "open",
+          "attachment",
+          "best attachment",
+          "primary",
+          "pdf",
+          "epub",
+          "snapshot",
+        ],
         contexts: ["main", "reader", "note"],
         icon: "note",
         group: "Workflow",
@@ -332,6 +353,13 @@ export class CommandRegistry {
           if (!parent || !parent.isRegularItem()) {
             return { enabled: false, reason: "Select an item first" };
           }
+          const attachmentIDs = (parent as any).getAttachments?.() || [];
+          if (!attachmentIDs.length) {
+            return {
+              enabled: false,
+              reason: "Current item does not have any attachment",
+            };
+          }
           return { enabled: true };
         },
         run: async ({ pane, activeItem }) => {
@@ -343,15 +371,23 @@ export class CommandRegistry {
             return;
           }
           await pane.newNote(false, parent.key);
-          const attachmentID = await getBestPdfAttachmentID(parent);
+          const attachmentID = await getBestAttachmentID(parent);
           if (!attachmentID) {
             return;
           }
-          if (shouldUseExternalPdfHandler()) {
+          const attachment = Zotero.Items.get(attachmentID) as Zotero.Item;
+          if (!attachment) {
+            return;
+          }
+          const attachmentType = getAttachmentResultType(attachment);
+          if (shouldUseExternalHandler(attachmentType)) {
             pane.viewAttachment?.(attachmentID);
             return;
           }
-          if (typeof (Zotero as any).Reader?.open === "function") {
+          if (
+            attachmentType === "pdf" &&
+            typeof (Zotero as any).Reader?.open === "function"
+          ) {
             await (Zotero as any).Reader.open(attachmentID, {
               openInWindow: false,
             });
@@ -507,28 +543,31 @@ export class CommandRegistry {
       },
       {
         id: "show-pdf-in-file-manager",
-        title: `Show PDF in ${getFileManagerLabel()}`,
-        subtitle: `Reveal the current PDF file in ${getFileManagerLabel()}`,
+        title: `Show Attachment in ${getFileManagerLabel()}`,
+        subtitle: `Reveal the current PDF, EPUB, or Snapshot file in ${getFileManagerLabel()}`,
         keywords: [
           "finder",
           "explorer",
           "reveal",
           "show file",
           "pdf",
+          "epub",
+          "snapshot",
           "attachment",
         ],
         contexts: ["main", "reader", "note"],
-        icon: "collection",
+        icon: "show-file",
         group: "Navigation",
         isAvailable: ({ activeItem }) => {
           const parent = getParentForCommand(activeItem);
           if (!parent || !parent.isRegularItem()) {
             return { enabled: false, reason: "Select an item first" };
           }
-          if (!hasPdfAttachment(parent)) {
+          if (!hasRevealableAttachment(parent)) {
             return {
               enabled: false,
-              reason: "Current item does not have a PDF attachment",
+              reason:
+                "Current item does not have a PDF, EPUB, or Snapshot attachment",
             };
           }
           return { enabled: true };
@@ -538,7 +577,7 @@ export class CommandRegistry {
           if (!parent || !parent.isRegularItem()) {
             return;
           }
-          const attachmentID = await getBestPdfAttachmentID(parent);
+          const attachmentID = await getBestRevealableAttachmentID(parent);
           if (!attachmentID) {
             return;
           }
@@ -640,6 +679,56 @@ async function getBestPdfAttachmentID(
   for (const attachmentID of attachmentIDs) {
     const attachment = Zotero.Items.get(attachmentID) as Zotero.Item;
     if (attachment && isPDFAttachment(attachment)) {
+      return attachmentID;
+    }
+  }
+  return null;
+}
+
+async function getBestAttachmentID(item: Zotero.Item): Promise<number | null> {
+  const candidate = item as any;
+  if (typeof candidate.getBestAttachment === "function") {
+    const best = await candidate.getBestAttachment();
+    if (typeof best === "number") {
+      const bestItem = Zotero.Items.get(best) as Zotero.Item;
+      return bestItem && bestItem.isAttachment() ? best : null;
+    }
+    if (best?.id) {
+      const bestItem = Zotero.Items.get(best.id) as Zotero.Item;
+      return bestItem && bestItem.isAttachment() ? (best.id as number) : null;
+    }
+  }
+  const attachmentIDs = candidate.getAttachments?.() || [];
+  for (const attachmentID of attachmentIDs) {
+    const attachment = Zotero.Items.get(attachmentID) as Zotero.Item;
+    if (attachment && attachment.isAttachment()) {
+      return attachmentID;
+    }
+  }
+  return null;
+}
+
+async function getBestRevealableAttachmentID(
+  item: Zotero.Item,
+): Promise<number | null> {
+  const candidate = item as any;
+  if (typeof candidate.getBestAttachment === "function") {
+    const best = await candidate.getBestAttachment();
+    if (typeof best === "number") {
+      const bestItem = Zotero.Items.get(best) as Zotero.Item;
+      return bestItem && isRevealableAttachment(bestItem) ? best : null;
+    }
+    if (best?.id) {
+      const bestItem = Zotero.Items.get(best.id) as Zotero.Item;
+      return bestItem && isRevealableAttachment(bestItem)
+        ? (best.id as number)
+        : null;
+    }
+  }
+  const attachmentIDs = candidate.getAttachments?.() || [];
+  for (const attachmentID of attachmentIDs) {
+    const attachment = Zotero.Items.get(attachmentID) as Zotero.Item;
+    if (attachment && isRevealableAttachment(attachment)) {
       return attachmentID;
     }
   }
@@ -768,6 +857,23 @@ function hasPdfAttachment(item: Zotero.Item): boolean {
   return false;
 }
 
+function hasRevealableAttachment(item: Zotero.Item): boolean {
+  const candidate = item as any;
+  const attachmentIDs = candidate.getAttachments?.() || [];
+  for (const attachmentID of attachmentIDs) {
+    const attachment = Zotero.Items.get(attachmentID) as Zotero.Item;
+    if (attachment && isRevealableAttachment(attachment)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isRevealableAttachment(item: Zotero.Item): boolean {
+  const type = getAttachmentResultType(item);
+  return type === "pdf" || type === "epub" || type === "snapshot";
+}
+
 async function revealAttachmentInFileManager(
   attachmentID: number,
 ): Promise<void> {
@@ -795,8 +901,21 @@ function isPDFAttachment(item: Zotero.Item): boolean {
   return String(contentType).toLowerCase().includes("pdf");
 }
 
-function shouldUseExternalPdfHandler(): boolean {
-  const handler = String(Zotero.Prefs.get("fileHandler.pdf") || "").trim();
+function shouldUseExternalHandler(
+  attachmentType: AttachmentResultType,
+): boolean {
+  const prefKey =
+    attachmentType === "pdf"
+      ? "fileHandler.pdf"
+      : attachmentType === "epub"
+        ? "fileHandler.epub"
+        : attachmentType === "snapshot"
+          ? "fileHandler.snapshot"
+          : "";
+  if (!prefKey) {
+    return false;
+  }
+  const handler = String(Zotero.Prefs.get(prefKey) || "").trim();
   return handler.length > 0;
 }
 
@@ -808,6 +927,16 @@ function getFileManagerLabel(): string {
     return "Explorer";
   }
   return "File Manager";
+}
+
+function getZoteroShortcut(prefKey: string, fallbackKey: string): string {
+  const modifier = Zotero.isMac
+    ? Zotero.getString("general.keys.cmdShift")
+    : Zotero.getString("general.keys.ctrlShift");
+  const key = String(Zotero.Prefs.get(prefKey) || fallbackKey)
+    .trim()
+    .toUpperCase();
+  return `${modifier}${key}`;
 }
 
 function getCreatorLine(item: Zotero.Item): string {

--- a/src/modules/spotlight/commands.ts
+++ b/src/modules/spotlight/commands.ts
@@ -279,10 +279,7 @@ export class CommandRegistry {
         subtitle: "Copy bibliography for selected/current item",
         keywords: ["quick copy", "reference", "bibliography", "clipboard"],
         contexts: ["main", "reader", "note"],
-        shortcut: getZoteroShortcut(
-          "keys.copySelectedItemsToClipboard",
-          "C",
-        ),
+        shortcut: getZoteroShortcut("keys.copySelectedItemsToClipboard", "C"),
         icon: "copy-bibliography",
         group: "Export",
         isAvailable: ({ pane, activeItem }) => {

--- a/src/modules/spotlight/commands.ts
+++ b/src/modules/spotlight/commands.ts
@@ -441,13 +441,16 @@ export class CommandRegistry {
       {
         id: "extract-highlights",
         title: "Extract Highlights",
-        subtitle: "Create a note from PDF highlights and annotation comments",
+        subtitle:
+          "Create a note from PDF, EPUB, or Snapshot highlights and annotation comments",
         keywords: [
           "workflow",
           "extract highlights",
           "annotations",
           "highlights",
           "pdf",
+          "epub",
+          "snapshot",
         ],
         contexts: ["main", "reader", "note"],
         icon: "note",
@@ -466,10 +469,11 @@ export class CommandRegistry {
           if (!parent || !parent.isRegularItem()) {
             return { enabled: false, reason: "Select an item first" };
           }
-          if (!hasPdfAttachment(parent)) {
+          if (!hasRevealableAttachment(parent)) {
             return {
               enabled: false,
-              reason: "Current item does not have a PDF attachment",
+              reason:
+                "Current item does not have a PDF, EPUB, or Snapshot attachment",
             };
           }
           return { enabled: true };
@@ -479,7 +483,7 @@ export class CommandRegistry {
           if (!pane || !parent || !parent.isRegularItem()) {
             return;
           }
-          const attachmentID = await getBestPdfAttachmentID(parent);
+          const attachmentID = await getBestRevealableAttachmentID(parent);
           if (!attachmentID) {
             return;
           }
@@ -660,31 +664,6 @@ function getFirstCollectionID(item: Zotero.Item): number | null {
   return typeof collectionID === "number" ? collectionID : null;
 }
 
-async function getBestPdfAttachmentID(
-  item: Zotero.Item,
-): Promise<number | null> {
-  const candidate = item as any;
-  if (typeof candidate.getBestAttachment === "function") {
-    const best = await candidate.getBestAttachment();
-    if (typeof best === "number") {
-      const bestItem = Zotero.Items.get(best) as Zotero.Item;
-      return bestItem && isPDFAttachment(bestItem) ? best : null;
-    }
-    if (best?.id) {
-      const bestItem = Zotero.Items.get(best.id) as Zotero.Item;
-      return bestItem && isPDFAttachment(bestItem) ? (best.id as number) : null;
-    }
-  }
-  const attachmentIDs = candidate.getAttachments?.() || [];
-  for (const attachmentID of attachmentIDs) {
-    const attachment = Zotero.Items.get(attachmentID) as Zotero.Item;
-    if (attachment && isPDFAttachment(attachment)) {
-      return attachmentID;
-    }
-  }
-  return null;
-}
-
 async function getBestAttachmentID(item: Zotero.Item): Promise<number | null> {
   const candidate = item as any;
   if (typeof candidate.getBestAttachment === "function") {
@@ -803,6 +782,13 @@ function buildExtractHighlightsNoteContent(
   attachment: Zotero.Item,
 ): string {
   const title = escapeHTML(parent.getDisplayTitle?.() || "Untitled");
+  const sourceType = getAttachmentResultType(attachment);
+  const sourceTypeLabel =
+    sourceType === "item"
+      ? "Attachment"
+      : sourceType === "snapshot"
+        ? "Snapshot"
+        : sourceType.toUpperCase();
   const annotations = [...(attachment.getAnnotations?.() || [])]
     .filter((annotation) => {
       const text = annotation.annotationText?.trim() || "";
@@ -835,26 +821,14 @@ function buildExtractHighlightsNoteContent(
   return `
     <h1>Extracted highlights</h1>
     <h2>${title}</h2>
-    <p><strong>Source PDF</strong>: ${escapeHTML(
+    <p><strong>Source ${escapeHTML(sourceTypeLabel)}</strong>: ${escapeHTML(
       (attachment as any).attachmentFilename ||
         attachment.getDisplayTitle?.() ||
-        "PDF",
+        sourceTypeLabel,
     )}</p>
     <p><strong>Total annotations</strong>: ${annotations.length}</p>
     <ol>${entriesHTML}</ol>
   `;
-}
-
-function hasPdfAttachment(item: Zotero.Item): boolean {
-  const candidate = item as any;
-  const attachmentIDs = candidate.getAttachments?.() || [];
-  for (const attachmentID of attachmentIDs) {
-    const attachment = Zotero.Items.get(attachmentID) as Zotero.Item;
-    if (attachment && isPDFAttachment(attachment)) {
-      return true;
-    }
-  }
-  return false;
 }
 
 function hasRevealableAttachment(item: Zotero.Item): boolean {
@@ -889,16 +863,6 @@ async function revealAttachmentInFileManager(
     return;
   }
   await Zotero.File.reveal(filePath);
-}
-
-function isPDFAttachment(item: Zotero.Item): boolean {
-  const candidate = item as any;
-  if (typeof candidate.isPDFAttachment === "function") {
-    return !!candidate.isPDFAttachment();
-  }
-  const contentType =
-    candidate.attachmentContentType || candidate.attachmentMIMEType || "";
-  return String(contentType).toLowerCase().includes("pdf");
 }
 
 function shouldUseExternalHandler(

--- a/src/modules/spotlight/itemMetadata.ts
+++ b/src/modules/spotlight/itemMetadata.ts
@@ -100,14 +100,44 @@ export function getItemNoteSnippetSafe(
   }
 }
 
-export function isPDFAttachment(item: Zotero.Item): boolean {
+export type AttachmentResultType = "item" | "pdf" | "epub" | "snapshot";
+
+export function getAttachmentResultType(
+  item: Zotero.Item,
+): AttachmentResultType {
   const candidate = item as any;
   if (typeof candidate.isPDFAttachment === "function") {
-    return !!candidate.isPDFAttachment();
+    if (candidate.isPDFAttachment()) {
+      return "pdf";
+    }
   }
-  const contentType =
-    candidate.attachmentContentType || candidate.attachmentMIMEType || "";
-  return String(contentType).toLowerCase().includes("pdf");
+  const contentType = String(
+    candidate.attachmentContentType || candidate.attachmentMIMEType || "",
+  ).toLowerCase();
+  if (contentType.includes("pdf")) {
+    return "pdf";
+  }
+  if (typeof candidate.isEPUBAttachment === "function") {
+    if (candidate.isEPUBAttachment()) {
+      return "epub";
+    }
+  }
+  if (typeof candidate.isSnapshotAttachment === "function") {
+    if (candidate.isSnapshotAttachment()) {
+      return "snapshot";
+    }
+  }
+  if (contentType.includes("epub")) {
+    return "epub";
+  }
+  if (contentType.includes("html") || contentType.includes("xhtml")) {
+    return "snapshot";
+  }
+  return "item";
+}
+
+export function isPDFAttachment(item: Zotero.Item): boolean {
+  return getAttachmentResultType(item) === "pdf";
 }
 
 function safeGetField(

--- a/src/modules/spotlight/itemMetadata.ts
+++ b/src/modules/spotlight/itemMetadata.ts
@@ -136,10 +136,6 @@ export function getAttachmentResultType(
   return "item";
 }
 
-export function isPDFAttachment(item: Zotero.Item): boolean {
-  return getAttachmentResultType(item) === "pdf";
-}
-
 function safeGetField(
   item: Zotero.Item,
   field: string,

--- a/src/modules/spotlight/palette.ts
+++ b/src/modules/spotlight/palette.ts
@@ -16,8 +16,16 @@ import {
   getItemTagsSafe,
   getItemTitleSafe,
   getItemYearSafe,
-  isPDFAttachment,
 } from "./itemMetadata";
+import {
+  getAttachmentParentItem,
+  getAttachmentTypeMeta,
+  getBestOpenableAttachmentID,
+  getParentForCommand,
+  getParentItem,
+  getPreferredOpenableAttachmentResultType,
+  isOpenableAttachmentType,
+} from "./attachmentHelpers";
 import { getPref } from "../../utils/prefs";
 
 const HTML_NS = "http://www.w3.org/1999/xhtml";
@@ -360,6 +368,11 @@ export class PaletteUI {
         if (!itemID) continue;
         const item = Zotero.Items.get(itemID) as any;
         if (!item) continue;
+        const attachmentResultType = item.isAttachment?.()
+          ? getAttachmentResultType(item as Zotero.Item)
+          : "item";
+        const attachmentTypeLabel =
+          getAttachmentTypeMeta(attachmentResultType).label;
         const parent = item.isAttachment?.()
           ? (Zotero.Items.get(item.parentID) as any)
           : item;
@@ -369,12 +382,10 @@ export class PaletteUI {
           title: item.isAttachment?.()
             ? parent?.getDisplayTitle?.() ||
               (item as any).attachmentFilename ||
-              "PDF"
+              attachmentTypeLabel
             : item.getDisplayTitle?.() || "Untitled",
-          subtitle: item.isAttachment?.() ? "PDF" : "Item",
-          resultType: item.isAttachment?.()
-            ? getAttachmentResultType(item as Zotero.Item)
-            : "item",
+          subtitle: item.isAttachment?.() ? attachmentTypeLabel : "Item",
+          resultType: attachmentResultType,
           libraryKind: "user",
           score: 10,
         });
@@ -1608,7 +1619,7 @@ export class PaletteUI {
       | string
       | undefined;
     const title = filename || getItemTitleSafe(attachment);
-    const parent = this.getAttachmentParentItem(attachment);
+    const parent = getAttachmentParentItem(attachment);
     const subtitle = parent ? getItemTitleSafe(parent) : "";
     const tags = parent ? getItemTagsSafe(parent, 3) : [];
     const abstractSnippet = parent
@@ -1645,21 +1656,6 @@ export class PaletteUI {
       authors: getItemAuthorsSafe(item),
       abstractSnippet: getItemAbstractSnippetSafe(item, 90),
     };
-  }
-
-  private getAttachmentParentItem(attachment: Zotero.Item): Zotero.Item | null {
-    const parentID =
-      (attachment as any).parentID ?? (attachment as any).parentItemID;
-    if (typeof parentID === "number") {
-      return Zotero.Items.get(parentID) as Zotero.Item;
-    }
-    const topLevel = (attachment as any).topLevelItem as
-      | Zotero.Item
-      | undefined;
-    if (topLevel && topLevel.id && topLevel.id !== attachment.id) {
-      return topLevel;
-    }
-    return null;
   }
 
   private createNoteResult(noteID: number): QuickOpenResult | null {
@@ -1997,7 +1993,7 @@ export class PaletteUI {
       );
     }
     if (result.kind === "attachment" && item?.isAttachment?.()) {
-      const parent = this.getAttachmentParentItem(item);
+      const parent = getAttachmentParentItem(item);
       if (parent) {
         return (
           getItemAbstractSnippetSafe(parent, 420) ||
@@ -2024,6 +2020,12 @@ export class PaletteUI {
     }
     if (result.resultType === "pdf") {
       return "Open the PDF in the Zotero reader.";
+    }
+    if (result.resultType === "epub") {
+      return "Open the EPUB in the Zotero reader.";
+    }
+    if (result.resultType === "snapshot") {
+      return "Open the Snapshot in the Zotero reader.";
     }
     return "Inspect the result here, then open it when you are ready.";
   }
@@ -2097,7 +2099,7 @@ export class PaletteUI {
           },
         },
         {
-          id: "open-pdf-window",
+          id: "open-attachment-window",
           label: `Open ${sourceMeta.label} in window`,
           icon: {
             itemType: sourceMeta.itemType,
@@ -2196,12 +2198,12 @@ export class PaletteUI {
         : true,
     );
 
-    const pdfAction = this.createOpenPdfPanelAction(result);
-    if (pdfAction) {
-      actions.splice(1, 0, pdfAction);
+    const openAttachmentAction = this.createOpenAttachmentPanelAction(result);
+    if (openAttachmentAction) {
+      actions.splice(1, 0, openAttachmentAction);
     }
 
-    const revealFileAction = this.createRevealPdfFilePanelAction(result);
+    const revealFileAction = this.createRevealAttachmentFilePanelAction(result);
     if (revealFileAction) {
       actions.splice(2, 0, revealFileAction);
     }
@@ -2224,23 +2226,32 @@ export class PaletteUI {
     return actions;
   }
 
-  private createOpenPdfPanelAction(
+  private createOpenAttachmentPanelAction(
     result: QuickOpenResult,
   ): PanelAction | null {
-    if (result.kind === "attachment" && result.resultType === "pdf") {
+    if (
+      result.kind === "attachment" &&
+      isOpenableAttachmentType(result.resultType)
+    ) {
       return null;
     }
     if (result.resultType === "note") {
       const note = Zotero.Items.get(result.id) as Zotero.Item | null;
-      const parent = note ? this.getParentItem(note) : null;
-      if (!parent || !this.hasPdfAttachment(parent)) {
+      const parent = note ? getParentItem(note) : null;
+      const preferredType = parent
+        ? getPreferredOpenableAttachmentResultType(parent)
+        : null;
+      if (!parent || !preferredType) {
         return null;
       }
       return {
-        id: "open-parent-pdf",
-        label: "Open parent PDF",
-        icon: { itemType: "attachmentPDF", text: "↗" },
-        hint: "Open the closest PDF attached to the parent item",
+        id: "open-parent-attachment",
+        label: `Open parent ${getAttachmentTypeMeta(preferredType).label}`,
+        icon: {
+          itemType: getAttachmentTypeMeta(preferredType).itemType,
+          text: "↗",
+        },
+        hint: "Open the closest PDF/EPUB/Snapshot attachment on the parent item",
         run: async () => {
           const attachmentID = await this.getPrimaryAttachmentID(parent.id);
           if (!attachmentID) {
@@ -2256,14 +2267,20 @@ export class PaletteUI {
       return null;
     }
     const item = Zotero.Items.get(result.id) as Zotero.Item | null;
-    if (!item || !this.hasPdfAttachment(item)) {
+    const preferredType = item
+      ? getPreferredOpenableAttachmentResultType(item)
+      : null;
+    if (!item || !preferredType) {
       return null;
     }
     return {
-      id: "open-pdf",
-      label: "Open PDF",
-      icon: { itemType: "attachmentPDF", text: "↗" },
-      hint: "Open the best attachment for this item",
+      id: "open-attachment",
+      label: `Open ${getAttachmentTypeMeta(preferredType).label}`,
+      icon: {
+        itemType: getAttachmentTypeMeta(preferredType).itemType,
+        text: "↗",
+      },
+      hint: "Open the best PDF/EPUB/Snapshot attachment for this item",
       run: async () => {
         const attachmentID = await this.getPrimaryAttachmentID(result.id);
         if (!attachmentID) {
@@ -2287,7 +2304,7 @@ export class PaletteUI {
     }
     const parent =
       item.isAttachment?.() || item.isNote?.()
-        ? this.getParentItem(item) || this.getAttachmentParentItem(item)
+        ? getParentItem(item) || getAttachmentParentItem(item)
         : null;
     if (!parent) {
       return null;
@@ -2379,13 +2396,16 @@ export class PaletteUI {
     };
   }
 
-  private createRevealPdfFilePanelAction(
+  private createRevealAttachmentFilePanelAction(
     result: QuickOpenResult,
   ): PanelAction | null {
     const label = `Show in ${this.getFileManagerLabel()}`;
-    if (result.kind === "attachment" && result.resultType === "pdf") {
+    if (
+      result.kind === "attachment" &&
+      isOpenableAttachmentType(result.resultType)
+    ) {
       return {
-        id: "reveal-pdf-file",
+        id: "reveal-attachment-file",
         label,
         icon: this.getActionCommandIcon("show-file", "⌕"),
         run: async () => {
@@ -2399,7 +2419,7 @@ export class PaletteUI {
       typeof result.attachmentID === "number"
     ) {
       return {
-        id: "reveal-annotation-pdf-file",
+        id: "reveal-annotation-attachment-file",
         label,
         icon: this.getActionCommandIcon("show-file", "⌕"),
         run: async () => {
@@ -2410,12 +2430,12 @@ export class PaletteUI {
     }
     if (result.resultType === "note") {
       const note = Zotero.Items.get(result.id) as Zotero.Item | null;
-      const parent = note ? this.getParentItem(note) : null;
-      if (!parent || !this.hasPdfAttachment(parent)) {
+      const parent = note ? getParentItem(note) : null;
+      if (!parent || !getPreferredOpenableAttachmentResultType(parent)) {
         return null;
       }
       return {
-        id: "reveal-parent-pdf-file",
+        id: "reveal-parent-attachment-file",
         label,
         icon: this.getActionCommandIcon("show-file", "⌕"),
         run: async () => {
@@ -2432,11 +2452,11 @@ export class PaletteUI {
       return null;
     }
     const item = Zotero.Items.get(result.id) as Zotero.Item | null;
-    if (!item || !this.hasPdfAttachment(item)) {
+    if (!item || !getPreferredOpenableAttachmentResultType(item)) {
       return null;
     }
     return {
-      id: "reveal-item-pdf-file",
+      id: "reveal-item-attachment-file",
       label,
       icon: this.getActionCommandIcon("show-file", "⌕"),
       run: async () => {
@@ -2543,16 +2563,8 @@ export class PaletteUI {
     }
   }
 
-  private getParentItem(item: Zotero.Item): Zotero.Item | null {
-    const parentID = (item as any).parentID ?? (item as any).parentItemID;
-    if (typeof parentID === "number") {
-      return Zotero.Items.get(parentID) as Zotero.Item;
-    }
-    return null;
-  }
-
   private getCitationTarget(item: Zotero.Item | null): Zotero.Item | null {
-    const parent = item ? this.getParentForCommand(item) : null;
+    const parent = item ? getParentForCommand(item) : null;
     if (!parent) {
       return null;
     }
@@ -2565,57 +2577,12 @@ export class PaletteUI {
     return parent;
   }
 
-  private getParentForCommand(item: Zotero.Item | null): Zotero.Item | null {
-    if (!item) {
-      return null;
-    }
-    if (item.isRegularItem()) {
-      return item;
-    }
-    const candidate = item as any;
-    const parentID = candidate.parentID ?? candidate.parentItemID;
-    if (typeof parentID === "number") {
-      return Zotero.Items.get(parentID) as Zotero.Item;
-    }
-    const topLevel = candidate.topLevelItem as Zotero.Item | undefined;
-    if (topLevel && topLevel.id && topLevel.id !== item.id) {
-      return topLevel;
-    }
-    return item;
-  }
-
   private async getPrimaryAttachmentID(itemID: number): Promise<number | null> {
     const item = Zotero.Items.get(itemID) as Zotero.Item;
     if (!item) {
       return null;
     }
-    const candidate = item as any;
-    if (typeof candidate.getBestAttachment === "function") {
-      const best = await candidate.getBestAttachment();
-      if (typeof best === "number") {
-        return best;
-      }
-      if (best?.id) {
-        return best.id as number;
-      }
-    }
-    if (typeof candidate.getPrimaryAttachment === "function") {
-      const primary = await candidate.getPrimaryAttachment();
-      if (typeof primary === "number") {
-        return primary;
-      }
-      if (primary?.id) {
-        return primary.id as number;
-      }
-    }
-    const attachmentIDs = candidate.getAttachments?.() || [];
-    for (const attachmentID of attachmentIDs) {
-      const attachment = Zotero.Items.get(attachmentID) as Zotero.Item;
-      if (attachment && isPDFAttachment(attachment)) {
-        return attachmentID;
-      }
-    }
-    return null;
+    return getBestOpenableAttachmentID(item);
   }
 
   private getItemTypeIconNameForItem(item: Zotero.Item | null): string | null {
@@ -2651,18 +2618,6 @@ export class PaletteUI {
     return item.isAttachment() ? "attachment" : "document";
   }
 
-  private hasPdfAttachment(item: Zotero.Item): boolean {
-    const candidate = item as any;
-    const attachmentIDs = candidate.getAttachments?.() || [];
-    for (const attachmentID of attachmentIDs) {
-      const attachment = Zotero.Items.get(attachmentID) as Zotero.Item;
-      if (attachment && isPDFAttachment(attachment)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   private getAnnotationSourceMeta(result: AnnotationResult): {
     label: string;
     itemType: string;
@@ -2673,24 +2628,11 @@ export class PaletteUI {
       const attachment = Zotero.Items.get(attachmentID) as Zotero.Item | null;
       if (attachment?.isAttachment?.()) {
         const resultType = getAttachmentResultType(attachment);
-        if (resultType === "pdf") {
+        if (isOpenableAttachmentType(resultType)) {
+          const meta = getAttachmentTypeMeta(resultType);
           return {
-            label: "PDF",
-            itemType: "attachmentPDF",
-            resultType,
-          };
-        }
-        if (resultType === "epub") {
-          return {
-            label: "EPUB",
-            itemType: "attachmentEPUB",
-            resultType,
-          };
-        }
-        if (resultType === "snapshot") {
-          return {
-            label: "Snapshot",
-            itemType: "attachmentSnapshot",
+            label: meta.label,
+            itemType: meta.itemType,
             resultType,
           };
         }
@@ -2898,7 +2840,7 @@ export class PaletteUI {
       return "chrome://zotero/skin/16/universal/folder-open.svg";
     }
     if (iconName === "annotate") {
-      return "chrome://zotero/skin/16/universal/annotate-highlight.svg";
+      return "chrome://zotero/skin/16/universal/annotation.svg";
     }
     return null;
   }

--- a/src/modules/spotlight/palette.ts
+++ b/src/modules/spotlight/palette.ts
@@ -528,18 +528,24 @@ export class PaletteUI {
     if (alternate === "reveal") {
       const attachmentID = result.attachmentID;
       if (typeof attachmentID === "number") {
+        const attachmentResult = this.createAttachmentResult(attachmentID);
         await this.actionHandler.openAttachment(attachmentID, false);
-        await this.actionHandler.openResult(
-          {
-            id: attachmentID,
-            kind: "attachment",
-            resultType: "pdf",
-            title: result.subtitle || "PDF",
-            subtitle: "PDF",
-            score: result.score,
-          },
-          "reveal",
-        );
+        if (attachmentResult) {
+          await this.actionHandler.openResult(attachmentResult, "reveal");
+        } else {
+          const sourceMeta = this.getAnnotationSourceMeta(result);
+          await this.actionHandler.openResult(
+            {
+              id: attachmentID,
+              kind: "attachment",
+              resultType: sourceMeta.resultType,
+              title: result.subtitle || sourceMeta.label,
+              subtitle: sourceMeta.label,
+              score: result.score,
+            },
+            "reveal",
+          );
+        }
       }
       return;
     }
@@ -1803,6 +1809,7 @@ export class PaletteUI {
     container: HTMLElement,
     result: AnnotationResult,
   ): void {
+    const sourceMeta = this.getAnnotationSourceMeta(result);
     const meta = [result.authors, result.year ? String(result.year) : ""]
       .filter(Boolean)
       .join(" - ");
@@ -1810,7 +1817,7 @@ export class PaletteUI {
       this.createPreviewHeader(
         "Annotation",
         result.subtitle || "Annotation result",
-        meta || "Jump directly to the matching annotation in the PDF reader.",
+        meta || "Jump directly to the matching annotation in the reader.",
       ),
     );
     this.appendPreviewChips(container, "spotlight-preview-meta", [
@@ -1818,7 +1825,7 @@ export class PaletteUI {
         label: result.pageLabel ? `Page ${result.pageLabel}` : "Annotation",
         color: result.annotationColor,
       },
-      { label: "PDF jump" },
+      { label: `${sourceMeta.label} jump` },
     ]);
     this.appendPreviewSection(container, "Matched text", result.title, true);
     if (result.abstractSnippet) {
@@ -2075,12 +2082,15 @@ export class PaletteUI {
       ];
     }
     if (result.kind === "annotation") {
+      const sourceMeta = this.getAnnotationSourceMeta(result);
+      const sourceLabel =
+        sourceMeta.label === "Attachment" ? "attachment" : sourceMeta.label;
       const actions: PanelAction[] = [
         {
           id: "open-annotation",
           label: "Open annotation",
           icon: this.getActionCommandIcon("annotate", "✦"),
-          hint: "Jump to the exact annotation in the PDF reader",
+          hint: "Jump to the exact annotation in the reader",
           run: async () => {
             await this.openAnnotation(result, "default");
             this.hide();
@@ -2088,12 +2098,12 @@ export class PaletteUI {
         },
         {
           id: "open-pdf-window",
-          label: "Open PDF in window",
+          label: `Open ${sourceMeta.label} in window`,
           icon: {
-            itemType: "attachmentPDF",
+            itemType: sourceMeta.itemType,
             text: "□",
           },
-          hint: "Open the source PDF in a separate reader window",
+          hint: `Open the source ${sourceLabel} in a separate reader window`,
           run: async () => {
             await this.openAnnotation(result, "alternate");
             this.hide();
@@ -2103,7 +2113,7 @@ export class PaletteUI {
           id: "reveal-attachment",
           label: "Reveal in library",
           icon: this.getActionCommandIcon("collection", "⌕"),
-          hint: "Select the source PDF in Zotero",
+          hint: `Select the source ${sourceLabel} in Zotero`,
           run: async () => {
             const attachmentResult = this.createAttachmentResult(
               result.attachmentID || 0,
@@ -2651,6 +2661,46 @@ export class PaletteUI {
       }
     }
     return false;
+  }
+
+  private getAnnotationSourceMeta(result: AnnotationResult): {
+    label: string;
+    itemType: string;
+    resultType: QuickOpenResult["resultType"];
+  } {
+    const attachmentID = result.attachmentID;
+    if (typeof attachmentID === "number") {
+      const attachment = Zotero.Items.get(attachmentID) as Zotero.Item | null;
+      if (attachment?.isAttachment?.()) {
+        const resultType = getAttachmentResultType(attachment);
+        if (resultType === "pdf") {
+          return {
+            label: "PDF",
+            itemType: "attachmentPDF",
+            resultType,
+          };
+        }
+        if (resultType === "epub") {
+          return {
+            label: "EPUB",
+            itemType: "attachmentEPUB",
+            resultType,
+          };
+        }
+        if (resultType === "snapshot") {
+          return {
+            label: "Snapshot",
+            itemType: "attachmentSnapshot",
+            resultType,
+          };
+        }
+      }
+    }
+    return {
+      label: "Attachment",
+      itemType: "attachment",
+      resultType: "item",
+    };
   }
 
   private getFileManagerLabel(): string {

--- a/src/modules/spotlight/palette.ts
+++ b/src/modules/spotlight/palette.ts
@@ -8,6 +8,7 @@ import type {
 } from "./search";
 import type { SearchService } from "./search";
 import {
+  getAttachmentResultType,
   getItemAbstractSnippetSafe,
   getItemAuthorsSafe,
   getItemNoteSnippetSafe,
@@ -371,7 +372,9 @@ export class PaletteUI {
               "PDF"
             : item.getDisplayTitle?.() || "Untitled",
           subtitle: item.isAttachment?.() ? "PDF" : "Item",
-          resultType: item.isAttachment?.() ? "pdf" : "item",
+          resultType: item.isAttachment?.()
+            ? getAttachmentResultType(item as Zotero.Item)
+            : "item",
           libraryKind: "user",
           score: 10,
         });
@@ -1609,7 +1612,7 @@ export class PaletteUI {
     return {
       id: attachmentID,
       kind: "attachment",
-      resultType: isPDFAttachment(attachment) ? "pdf" : "item",
+      resultType: getAttachmentResultType(attachment),
       title: title || "Attachment",
       subtitle,
       score: 0,
@@ -2076,10 +2079,7 @@ export class PaletteUI {
         {
           id: "open-annotation",
           label: "Open annotation",
-          icon: {
-            url: "chrome://zotero/skin/16/universal/annotate-highlight.svg",
-            text: "✦",
-          },
+          icon: this.getActionCommandIcon("annotate", "✦"),
           hint: "Jump to the exact annotation in the PDF reader",
           run: async () => {
             await this.openAnnotation(result, "default");
@@ -2102,10 +2102,7 @@ export class PaletteUI {
         {
           id: "reveal-attachment",
           label: "Reveal in library",
-          icon: {
-            url: "chrome://zotero/skin/16/universal/library-collection.svg",
-            text: "⌕",
-          },
+          icon: this.getActionCommandIcon("collection", "⌕"),
           hint: "Select the source PDF in Zotero",
           run: async () => {
             const attachmentResult = this.createAttachmentResult(
@@ -2131,16 +2128,17 @@ export class PaletteUI {
     const actions: PanelAction[] = [
       {
         id: "open-default",
-        label: result.resultType === "pdf" ? "Open PDF" : "Open",
+        label: this.getDefaultOpenActionLabel(result.resultType),
         icon:
           result.resultType === "pdf"
             ? { itemType: "attachmentPDF", text: "↗" }
             : result.resultType === "note"
-              ? {
-                  url: "chrome://zotero/skin/16/universal/note.svg",
-                  text: "↵",
-                }
-              : { itemType: "document", text: "↵" },
+              ? this.getActionCommandIcon("note", "↵")
+              : result.resultType === "epub"
+                ? { itemType: "attachmentEPUB", text: "↗" }
+                : result.resultType === "snapshot"
+                  ? { itemType: "attachmentSnapshot", text: "↗" }
+                  : { itemType: "document", text: "↵" },
         hint: "Open the selected result",
         run: async () => {
           await this.finishQuickOpen(result, "default");
@@ -2149,10 +2147,7 @@ export class PaletteUI {
       {
         id: "reveal-item",
         label: "Reveal in library",
-        icon: {
-          url: "chrome://zotero/skin/16/universal/library-collection.svg",
-          text: "⌕",
-        },
+        icon: this.getActionCommandIcon("collection", "⌕"),
         hint: "Select this item in the Zotero main pane",
         run: async () => {
           await this.finishQuickOpen(result, "reveal");
@@ -2161,13 +2156,22 @@ export class PaletteUI {
       {
         id: "open-alternate",
         label:
-          result.resultType === "pdf" || result.resultType === "note"
+          result.resultType === "pdf" ||
+          result.resultType === "note" ||
+          result.resultType === "epub" ||
+          result.resultType === "snapshot"
             ? "Open in new window"
             : "Open in alternate mode",
         icon:
           result.resultType === "pdf"
             ? { itemType: "attachmentPDF", text: "□" }
-            : { itemType: "document", text: "□" },
+            : result.resultType === "epub"
+              ? { itemType: "attachmentEPUB", text: "□" }
+              : result.resultType === "snapshot"
+                ? { itemType: "attachmentSnapshot", text: "□" }
+                : result.resultType === "note"
+                  ? this.getActionCommandIcon("note", "□")
+                  : { itemType: "document", text: "□" },
         hint: "Use the alternate open behavior",
         run: async () => {
           await this.finishQuickOpen(result, "alternate");
@@ -2175,7 +2179,10 @@ export class PaletteUI {
       },
     ].filter((action) =>
       action.id === "open-alternate"
-        ? result.resultType === "pdf" || result.resultType === "note"
+        ? result.resultType === "pdf" ||
+          result.resultType === "note" ||
+          result.resultType === "epub" ||
+          result.resultType === "snapshot"
         : true,
     );
 
@@ -2333,7 +2340,7 @@ export class PaletteUI {
       return {
         id: "copy-annotation-content",
         label: "Copy Content",
-        icon: this.getActionCommandIcon("copy-citation", "C"),
+        icon: this.getActionCommandIcon("annotate", "C"),
         run: async () => {
           this.copyTextToClipboard(content);
           this.hide();
@@ -2354,7 +2361,7 @@ export class PaletteUI {
     return {
       id: "copy-note-content",
       label: "Copy Content",
-      icon: this.getActionCommandIcon("copy-citation", "C"),
+      icon: this.getActionCommandIcon("note", "C"),
       run: async () => {
         this.copyTextToClipboard(content);
         this.hide();
@@ -2370,10 +2377,7 @@ export class PaletteUI {
       return {
         id: "reveal-pdf-file",
         label,
-        icon: {
-          url: "chrome://zotero/skin/16/universal/library-collection.svg",
-          text: "⌕",
-        },
+        icon: this.getActionCommandIcon("show-file", "⌕"),
         run: async () => {
           await this.actionHandler.revealAttachmentFile(result.id);
           this.hide();
@@ -2387,10 +2391,7 @@ export class PaletteUI {
       return {
         id: "reveal-annotation-pdf-file",
         label,
-        icon: {
-          url: "chrome://zotero/skin/16/universal/library-collection.svg",
-          text: "⌕",
-        },
+        icon: this.getActionCommandIcon("show-file", "⌕"),
         run: async () => {
           await this.actionHandler.revealAttachmentFile(result.attachmentID!);
           this.hide();
@@ -2406,10 +2407,7 @@ export class PaletteUI {
       return {
         id: "reveal-parent-pdf-file",
         label,
-        icon: {
-          url: "chrome://zotero/skin/16/universal/library-collection.svg",
-          text: "⌕",
-        },
+        icon: this.getActionCommandIcon("show-file", "⌕"),
         run: async () => {
           const attachmentID = await this.getPrimaryAttachmentID(parent.id);
           if (!attachmentID) {
@@ -2430,10 +2428,7 @@ export class PaletteUI {
     return {
       id: "reveal-item-pdf-file",
       label,
-      icon: {
-        url: "chrome://zotero/skin/16/universal/library-collection.svg",
-        text: "⌕",
-      },
+      icon: this.getActionCommandIcon("show-file", "⌕"),
       run: async () => {
         const attachmentID = await this.getPrimaryAttachmentID(result.id);
         if (!attachmentID) {
@@ -2849,6 +2844,12 @@ export class PaletteUI {
     if (iconName === "collection") {
       return "chrome://zotero/skin/16/universal/library-collection.svg";
     }
+    if (iconName === "show-file") {
+      return "chrome://zotero/skin/16/universal/folder-open.svg";
+    }
+    if (iconName === "annotate") {
+      return "chrome://zotero/skin/16/universal/annotate-highlight.svg";
+    }
     return null;
   }
 
@@ -2906,10 +2907,34 @@ export class PaletteUI {
     if (type === "note") {
       return "NOTE";
     }
+    if (type === "epub") {
+      return "EPUB";
+    }
+    if (type === "snapshot") {
+      return "SNAPSHOT";
+    }
     if (type === "annotation") {
       return "ANNO";
     }
     return "ITEM";
+  }
+
+  private getDefaultOpenActionLabel(
+    type: QuickOpenResult["resultType"],
+  ): string {
+    if (type === "pdf") {
+      return "Open PDF";
+    }
+    if (type === "note") {
+      return "Open Note";
+    }
+    if (type === "epub") {
+      return "Open EPUB";
+    }
+    if (type === "snapshot") {
+      return "Open Snapshot";
+    }
+    return "Open";
   }
 
   private pushRecentActivated(itemID: number): void {
@@ -3071,7 +3096,14 @@ export class PaletteUI {
       this.closeAutocomplete();
       return;
     }
-    const typeValues = ["pdf", "note", "item", "annotation"];
+    const typeValues = [
+      "pdf",
+      "epub",
+      "snapshot",
+      "note",
+      "item",
+      "annotation",
+    ];
     const yearValues = ["2024", "2023", "2020-2024", ">=2020", "<=2024"];
     let options: string[];
     if (context.prefix === ":") {

--- a/src/modules/spotlight/search.ts
+++ b/src/modules/spotlight/search.ts
@@ -1,11 +1,11 @@
 import {
+  getAttachmentResultType,
   getItemAbstractSnippetSafe,
   getItemAuthorsSafe,
   getItemSubtitleSafe,
   getItemTagsSafe,
   getItemTitleSafe,
   getItemYearSafe,
-  isPDFAttachment,
 } from "./itemMetadata";
 import { getPref } from "../../utils/prefs";
 
@@ -17,7 +17,13 @@ export type SearchRankingState = {
 };
 
 export type ResultKind = "item" | "attachment" | "annotation";
-export type ResultType = "item" | "note" | "pdf" | "annotation";
+export type ResultType =
+  | "item"
+  | "note"
+  | "pdf"
+  | "epub"
+  | "snapshot"
+  | "annotation";
 
 export interface BaseResult {
   id: number;
@@ -387,7 +393,7 @@ async function buildBaseIndex(): Promise<IndexedEntry[]> {
           entries.push({
             id: item.id,
             kind: "attachment",
-            resultType: isPDFAttachment(item) ? "pdf" : "item",
+            resultType: getAttachmentResultType(item),
             title,
             subtitle,
             authors,
@@ -897,6 +903,8 @@ function parseTypeFilter(rawValue: string): ResultType[] {
   for (const entry of values) {
     if (
       entry === "pdf" ||
+      entry === "epub" ||
+      entry === "snapshot" ||
       entry === "note" ||
       entry === "item" ||
       entry === "annotation"


### PR DESCRIPTION
## What changed

This pull request enhances attachment handling and user interface elements in the Spotlight module, improving support for multiple attachment types (PDF, EPUB, Snapshot) and refining preference and localization handling. The most notable changes are the generalization of attachment-related commands, improved shortcut handling, and expanded localization support.

**Attachment Handling Improvements:**

* Generalized attachment commands to support not only PDFs but also EPUB and Snapshot attachments, including updating command logic, icons, labels, and result types throughout `commands.ts` and `palette.ts`. This includes new helper functions such as `getBestAttachmentID`, `getBestRevealableAttachmentID`, `hasRevealableAttachment`, and `getAttachmentResultType` for more flexible attachment management. [[1]](diffhunk://#diff-86838481e163e0f75cb6d5b4ef5ba818c32a7d5c1428792ca4d1478486913e41R1-R5) [[2]](diffhunk://#diff-86838481e163e0f75cb6d5b4ef5ba818c32a7d5c1428792ca4d1478486913e41L314-R338) [[3]](diffhunk://#diff-86838481e163e0f75cb6d5b4ef5ba818c32a7d5c1428792ca4d1478486913e41R356-R362) [[4]](diffhunk://#diff-86838481e163e0f75cb6d5b4ef5ba818c32a7d5c1428792ca4d1478486913e41L346-R390) [[5]](diffhunk://#diff-86838481e163e0f75cb6d5b4ef5ba818c32a7d5c1428792ca4d1478486913e41L510-R570) [[6]](diffhunk://#diff-86838481e163e0f75cb6d5b4ef5ba818c32a7d5c1428792ca4d1478486913e41L541-R580) [[7]](diffhunk://#diff-86838481e163e0f75cb6d5b4ef5ba818c32a7d5c1428792ca4d1478486913e41R688-R737) [[8]](diffhunk://#diff-86838481e163e0f75cb6d5b4ef5ba818c32a7d5c1428792ca4d1478486913e41R860-R876) [[9]](diffhunk://#diff-86838481e163e0f75cb6d5b4ef5ba818c32a7d5c1428792ca4d1478486913e41L798-R918) [[10]](diffhunk://#diff-7fde2430ec10bf89edd16b618c520bba8f7ef3d83a3018e172a886afb454da1eL103-R140) [[11]](diffhunk://#diff-7f6131cbad2b8eb8f1b0a1537e5074174e603048b4e7e46f4dc77b2260520bc2R11) [[12]](diffhunk://#diff-7f6131cbad2b8eb8f1b0a1537e5074174e603048b4e7e46f4dc77b2260520bc2L374-R377) [[13]](diffhunk://#diff-7f6131cbad2b8eb8f1b0a1537e5074174e603048b4e7e46f4dc77b2260520bc2L1612-R1615)
* Updated UI elements and action panels in `palette.ts` to reflect the new attachment types, including dynamic icons, labels, and action hints for EPUBs and Snapshots in addition to PDFs. [[1]](diffhunk://#diff-7f6131cbad2b8eb8f1b0a1537e5074174e603048b4e7e46f4dc77b2260520bc2L2079-R2082) [[2]](diffhunk://#diff-7f6131cbad2b8eb8f1b0a1537e5074174e603048b4e7e46f4dc77b2260520bc2L2134-R2140) [[3]](diffhunk://#diff-7f6131cbad2b8eb8f1b0a1537e5074174e603048b4e7e46f4dc77b2260520bc2L2152-R2150)

**Shortcut and Preferences Handling:**

* Improved shortcut assignment by introducing a `getZoteroShortcut` helper, which dynamically generates shortcuts based on platform and user preferences, replacing hardcoded values. [[1]](diffhunk://#diff-86838481e163e0f75cb6d5b4ef5ba818c32a7d5c1428792ca4d1478486913e41L229-R237) [[2]](diffhunk://#diff-86838481e163e0f75cb6d5b4ef5ba818c32a7d5c1428792ca4d1478486913e41L274-R285) [[3]](diffhunk://#diff-86838481e163e0f75cb6d5b4ef5ba818c32a7d5c1428792ca4d1478486913e41R932-R941)

**Localization and UI Enhancements:**

* Updated English and Chinese localization files to use platform-specific shortcut labels (e.g., ⌘+P for macOS, Ctrl+P for others) using Fluent's `PLATFORM()` selector. [[1]](diffhunk://#diff-8b21f73c3b3b782dff21e947b73d8dd2dde9553b53d7d7efbebd451dddc368afL2-R9) [[2]](diffhunk://#diff-d04c18892ed72223035966c81d45fafcad02d90913fa5e57f6591fe1c213f06fL2-R9)
* Minor UI improvements in the preferences panel, such as adding orientation to shortcut options and improving number input controls for better usability. [[1]](diffhunk://#diff-c4fc1c0947464c11133cca736e3f65a4e99567a38d9fab884e046bdd1b260839R36) [[2]](diffhunk://#diff-c4fc1c0947464c11133cca736e3f65a4e99567a38d9fab884e046bdd1b260839R73-R74) [[3]](diffhunk://#diff-c4fc1c0947464c11133cca736e3f65a4e99567a38d9fab884e046bdd1b260839R93-R94) [[4]](diffhunk://#diff-c4fc1c0947464c11133cca736e3f65a4e99567a38d9fab884e046bdd1b260839R107-R108)

## How to test

- [x] `npm run lint:check`
- [x] `npm run build`
- [ ] `npm run test` (if relevant)
- [x] Tested in Zotero locally (if relevant)

## Notes

<img height="300" alt="image" src="https://github.com/user-attachments/assets/1e79ae01-f4fd-4e7c-b16d-023258276a0d" />

<img height="300" alt="image" src="https://github.com/user-attachments/assets/26869dc3-5056-4052-97d3-d5743b4a2577" />
