### PR TITLE
feat: support opening actions panel via right-click

### DIFF
--- a/src/modules/spotlight/palette.ts
+++ b/src/modules/spotlight/palette.ts
@@ -341,11 +341,12 @@ export class PaletteUI {
         void this.activateSelectedPanelAction();
         return;
       }
-      const intent: OpenIntent = event.shiftKey
-        ? "reveal"
-        : event.metaKey || event.ctrlKey
-          ? "alternate"
-          : "default";
+      const intent: OpenIntent =
+        event.metaKey || event.ctrlKey
+          ? "reveal"
+          : event.shiftKey
+            ? "alternate"
+            : "default";
       void this.activateSelection(intent);
     }
   }
@@ -709,8 +710,18 @@ export class PaletteUI {
         this.input.focus();
         this.updateSelectionState();
       });
-      row.addEventListener("click", () => {
-        void this.activateSelection("default");
+      row.addEventListener("click", (event: MouseEvent) => {
+        const intent: OpenIntent =
+          event.metaKey || event.ctrlKey
+            ? "reveal"
+            : event.shiftKey
+              ? "alternate"
+              : "default";
+        void this.activateSelection(intent);
+      });
+      row.addEventListener("contextmenu", (event) => {
+        event.preventDefault();
+        this.openActionsPanel();
       });
       this.list.appendChild(row);
     });

--- a/src/modules/spotlight/palette.ts
+++ b/src/modules/spotlight/palette.ts
@@ -247,6 +247,14 @@ export class PaletteUI {
     });
   }
 
+  private getOpenIntent(event: MouseEvent | KeyboardEvent): OpenIntent {
+    return event.metaKey || event.ctrlKey
+      ? "reveal"
+      : event.shiftKey
+        ? "alternate"
+        : "default";
+  }
+
   private handleKeydown(event: KeyboardEvent): void {
     if (!this.open) {
       return;
@@ -341,13 +349,7 @@ export class PaletteUI {
         void this.activateSelectedPanelAction();
         return;
       }
-      const intent: OpenIntent =
-        event.metaKey || event.ctrlKey
-          ? "reveal"
-          : event.shiftKey
-            ? "alternate"
-            : "default";
-      void this.activateSelection(intent);
+      void this.activateSelection(this.getOpenIntent(event));
     }
   }
 
@@ -711,13 +713,7 @@ export class PaletteUI {
         this.updateSelectionState();
       });
       row.addEventListener("click", (event: MouseEvent) => {
-        const intent: OpenIntent =
-          event.metaKey || event.ctrlKey
-            ? "reveal"
-            : event.shiftKey
-              ? "alternate"
-              : "default";
-        void this.activateSelection(intent);
+        void this.activateSelection(this.getOpenIntent(event));
       });
       row.addEventListener("contextmenu", (event) => {
         event.preventDefault();


### PR DESCRIPTION
## What changed

- enable click with modifier (Shift and Ctrl/Meta)

- swap Shift and Ctrl/Meta modifier key roles in OpenIntent logic

## Why

- align with Zotero's native behavior for Shift

## How to test

- [x] `npm run lint:check`
- [x] `npm run build`
- [x] `npm run test` (if relevant)
- [x] Tested in Zotero locally (if relevant)

## Notes

- Screenshots or GIFs for UI changes, if helpful
- Linked issue:
