### PR TITLE
feat: apply green color to best attachment badges

### DIFF
--- a/src/modules/spotlight/palette.ts
+++ b/src/modules/spotlight/palette.ts
@@ -391,6 +391,7 @@ export class PaletteUI {
         });
       }
       this.results = tabResults;
+      await this.markBestAttachmentBadges(this.results);
       this.sectionHeader = `Open Tabs (${tabResults.length})`;
       this.displayMode = "search";
       this.selectedIndex = 0;
@@ -399,6 +400,7 @@ export class PaletteUI {
     }
     if (!parsedQuery.isCommandMode && !this.currentQuery) {
       this.results = this.buildRecentResults();
+      await this.markBestAttachmentBadges(this.results);
       this.sectionHeader = "Recent";
       this.displayMode = "recent";
       this.selectedIndex = 0;
@@ -426,6 +428,7 @@ export class PaletteUI {
       return;
     }
     this.results = results;
+    await this.markBestAttachmentBadges(this.results);
     this.panelMode = "preview";
     this.selectedActionIndex = 0;
     this.updateBodyMode();
@@ -454,6 +457,23 @@ export class PaletteUI {
     this.selectedIndex = nextIndex;
     this.selectedActionIndex = 0;
     this.updateSelectionState();
+  }
+
+  private async markBestAttachmentBadges(
+    results: Array<QuickOpenResult | CommandResult | HistoryResult>,
+  ): Promise<void> {
+    for (const result of results) {
+      if (result.kind !== "attachment") {
+        continue;
+      }
+      const attachment = Zotero.Items.get(result.id) as Zotero.Item | null;
+      const parent = attachment ? getAttachmentParentItem(attachment) : null;
+      (
+        result as QuickOpenResult & { isBestAttachment?: boolean }
+      ).isBestAttachment =
+        !!parent?.isRegularItem?.() &&
+        (await getBestOpenableAttachmentID(parent)) === result.id;
+    }
   }
 
   private moveActionSelection(delta: number): void {
@@ -2893,9 +2913,18 @@ export class PaletteUI {
       badges.push("GROUP");
     }
 
-    badges.forEach((label) => {
+    const isBestAttachment =
+      result.kind === "attachment" &&
+      (result as QuickOpenResult & { isBestAttachment?: boolean })
+        .isBestAttachment === true;
+    badges.forEach((label, index) => {
       const badge = this.createElement("span", "spotlight-tag");
       badge.textContent = label;
+      if (isBestAttachment && index === 0) {
+        badge.style.color = "var(--tag-green)";
+        badge.title = "Best attachment";
+        badge.setAttribute("aria-label", "Best attachment");
+      }
       row.appendChild(badge);
     });
     if (isOpenTab) {

--- a/src/modules/spotlight/palette.ts
+++ b/src/modules/spotlight/palette.ts
@@ -1399,6 +1399,8 @@ export class PaletteUI {
   --quick-open-quote-bg: #efe9e0;
   --quick-open-command-icon-text: #3f3a32;
   --quick-open-image-icon-filter: none;
+  --quick-open-best-badge-bg: #c8e6c9;
+  --quick-open-best-badge-text: #1b5e20;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -1422,6 +1424,8 @@ export class PaletteUI {
     --quick-open-meta-chip-text: #f0dfc4;
     --quick-open-action-chip-bg: #2f4233;
     --quick-open-action-chip-text: #cde6d1;
+    --quick-open-best-badge-bg: #1b3a21;
+    --quick-open-best-badge-text: #81c784;
     --quick-open-tag-chip-bg: #243c4d;
     --quick-open-tag-chip-text: #c7e3f4;
     --quick-open-quote-bg: #2e2a26;
@@ -2921,7 +2925,8 @@ export class PaletteUI {
       const badge = this.createElement("span", "spotlight-tag");
       badge.textContent = label;
       if (isBestAttachment && index === 0) {
-        badge.style.color = "var(--tag-green)";
+        badge.style.color = "var(--quick-open-best-badge-text)";
+        badge.style.background = "var(--quick-open-best-badge-bg)";
         badge.title = "Best attachment";
         badge.setAttribute("aria-label", "Best attachment");
       }

--- a/src/modules/spotlight/palette.ts
+++ b/src/modules/spotlight/palette.ts
@@ -392,6 +392,7 @@ export class PaletteUI {
       }
       this.results = tabResults;
       await this.markBestAttachmentBadges(this.results);
+      if (token !== this.searchToken) return;
       this.sectionHeader = `Open Tabs (${tabResults.length})`;
       this.displayMode = "search";
       this.selectedIndex = 0;
@@ -401,6 +402,7 @@ export class PaletteUI {
     if (!parsedQuery.isCommandMode && !this.currentQuery) {
       this.results = this.buildRecentResults();
       await this.markBestAttachmentBadges(this.results);
+      if (token !== this.searchToken) return;
       this.sectionHeader = "Recent";
       this.displayMode = "recent";
       this.selectedIndex = 0;
@@ -429,6 +431,7 @@ export class PaletteUI {
     }
     this.results = results;
     await this.markBestAttachmentBadges(this.results);
+    if (token !== this.searchToken) return;
     this.panelMode = "preview";
     this.selectedActionIndex = 0;
     this.updateBodyMode();

--- a/src/modules/spotlight/palette.ts
+++ b/src/modules/spotlight/palette.ts
@@ -465,18 +465,20 @@ export class PaletteUI {
   private async markBestAttachmentBadges(
     results: Array<QuickOpenResult | CommandResult | HistoryResult>,
   ): Promise<void> {
-    for (const result of results) {
-      if (result.kind !== "attachment") {
-        continue;
-      }
-      const attachment = Zotero.Items.get(result.id) as Zotero.Item | null;
-      const parent = attachment ? getAttachmentParentItem(attachment) : null;
-      (
-        result as QuickOpenResult & { isBestAttachment?: boolean }
-      ).isBestAttachment =
-        !!parent?.isRegularItem?.() &&
-        (await getBestOpenableAttachmentID(parent)) === result.id;
-    }
+    await Promise.all(
+      results.map(async (result) => {
+        if (result.kind !== "attachment") {
+          return;
+        }
+        const attachment = Zotero.Items.get(result.id) as Zotero.Item | null;
+        const parent = attachment ? getAttachmentParentItem(attachment) : null;
+        (
+          result as QuickOpenResult & { isBestAttachment?: boolean }
+        ).isBestAttachment =
+          !!parent?.isRegularItem?.() &&
+          (await getBestOpenableAttachmentID(parent)) === result.id;
+      }),
+    );
   }
 
   private moveActionSelection(delta: number): void {


### PR DESCRIPTION
## What changed

- apply green color to best attachment badges

## Why

- To distinguish multiple attachments with the same file name

## How to test

- [x] `npm run lint:check`
- [x] `npm run build`
- [x] `npm run test` (if relevant)
- [x] Tested in Zotero locally (if relevant)

## Notes

- Screenshots or GIFs for UI changes, if helpful
- Linked issue:
