### PR TITLE
feat: shortcut guide overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Spotlight is different:
 ## Features
 
 - Open Spotlight with one shortcut: `Cmd+P` on macOS, `Ctrl+P` on Windows/Linux.
+- Open a shortcut cheat sheet with `Cmd+/` on macOS, `Ctrl+/` on Windows/Linux.
 - Works in the main Zotero window, reader, and note editor.
 
 ### 1. Search, Switch, Filter

--- a/README.md
+++ b/README.md
@@ -29,21 +29,25 @@ Spotlight is different:
 ## Features
 
 - Open Spotlight with one shortcut: `Cmd+P` on macOS, `Ctrl+P` on Windows/Linux.
-- Open a shortcut cheat sheet with `Cmd+/` on macOS, `Ctrl+/` on Windows/Linux.
+- Open a full keyboard shortcut reference with `Cmd+/` on macOS, `Ctrl+/` on Windows/Linux.
 - Works in the main Zotero window, reader, and note editor.
 
 ### 1. Search, Switch, Filter
 
 - Search across your library with fuzzy matching instead of being limited to the current collection.
 - Switch between items, notes, PDFs, annotations, and open tabs from one place.
-- Narrow results with `type:`, `tag:`, and `year:` filters, including combinations like `type:pdf year:2024`, or use `@query` to search annotations directly.
-- Use richer result rows and press `Right Arrow` on a selected result to open preview details and contextual actions.
+- Narrow results with filter sigils: `:pdf`, `:note`, `#tag`, `y:2024` — combinable, e.g. `:pdf y:2020-2024 neural`.
+- Search annotations directly with `@query`, or search indexed PDF text as an exact phrase with `=phrase`.
+- A filter hint bar below the search input shows all available filters as clickable badges; typing `:` or `#` triggers inline autocomplete.
+- Use richer result rows and press `Right Arrow` or right-click a result to open preview details and contextual actions.
 - Jump annotation results directly to the matching location in the PDF, with improved annotation-focused search relevance.
 - Get ranking boosts from recency, frequency, library scope, and recent-search history per window.
+- The primary/best attachment for each item is highlighted with a green badge in the result list.
 
 ### 2. Commands and Workflows
 
 - Use `>` to enter command mode for built-in actions like `New Note`, `Copy Citation`, `Copy Bibliography`, `Open Collection`, and `Show PDF/EPUB/Snapshot in Finder/Explorer`.
+- Run `>add note + open best attachment` to create a note and immediately open the item's primary PDF, EPUB, or Snapshot in one step.
 - Run reusable workflows like `>literature note` and `>extract highlights` for common research tasks.
 - Use `>tabs` to search and switch across currently open Zotero tabs.
 - Trigger context-aware commands based on the current Zotero window and selected item.

--- a/addon/content/preferences.xhtml
+++ b/addon/content/preferences.xhtml
@@ -136,6 +136,17 @@
         style="margin-left: 6px"
       ></html:label>
     </hbox>
+    <hbox align="center">
+      <html:input
+        type="checkbox"
+        id="zotero-prefpane-__addonRef__-show-filter-hint-bar"
+      />
+      <html:label
+        for="zotero-prefpane-__addonRef__-show-filter-hint-bar"
+        data-l10n-id="pref-show-filter-hint-bar"
+        style="margin-left: 6px"
+      ></html:label>
+    </hbox>
   </vbox>
   <vbox>
     <html:button

--- a/addon/locale/en-US/preferences.ftl
+++ b/addon/locale/en-US/preferences.ftl
@@ -16,4 +16,5 @@ pref-window-width = Width (px)
 pref-search-section = Search
 pref-search-annotations = Search annotations
 pref-restore-search = Restore last search when reopening Spotlight
+pref-show-filter-hint-bar = Show filter hint bar
 pref-reset-defaults = Reset to defaults

--- a/addon/locale/zh-CN/preferences.ftl
+++ b/addon/locale/zh-CN/preferences.ftl
@@ -16,4 +16,5 @@ pref-window-width = 宽度 (px)
 pref-search-section = 搜索
 pref-search-annotations = 搜索批注
 pref-restore-search = 重新打开 Spotlight 时恢复上一次搜索
+pref-show-filter-hint-bar = 显示过滤提示栏
 pref-reset-defaults = 恢复默认设置

--- a/src/modules/preferenceScript.ts
+++ b/src/modules/preferenceScript.ts
@@ -63,6 +63,13 @@ function syncPrefUI() {
   if (restoreCheckbox) {
     restoreCheckbox.checked = !!(getPref as any)("restoreSearch");
   }
+  const filterHintBarCheckbox = doc.querySelector(
+    `#zotero-prefpane-${config.addonRef}-show-filter-hint-bar`,
+  ) as HTMLInputElement | null;
+  if (filterHintBarCheckbox) {
+    const val = (getPref as any)("showFilterHintBar");
+    filterHintBarCheckbox.checked = val === undefined || val === null ? true : !!val;
+  }
 }
 
 function bindPrefEvents() {
@@ -110,6 +117,12 @@ function bindPrefEvents() {
   restoreCheckboxBind?.addEventListener("change", () => {
     (setPref as any)("restoreSearch", restoreCheckboxBind.checked);
   });
+  const filterHintBarCheckboxBind = doc.querySelector(
+    `#zotero-prefpane-${config.addonRef}-show-filter-hint-bar`,
+  ) as HTMLInputElement | null;
+  filterHintBarCheckboxBind?.addEventListener("change", () => {
+    (setPref as any)("showFilterHintBar", filterHintBarCheckboxBind.checked);
+  });
   const resetButton = doc.querySelector(
     `#zotero-prefpane-${config.addonRef}-reset-defaults`,
   ) as HTMLButtonElement | null;
@@ -119,6 +132,7 @@ function bindPrefEvents() {
     (setPref as any)("windowWidth", 560);
     (setPref as any)("searchAnnotations", true);
     (setPref as any)("restoreSearch", false);
+    (setPref as any)("showFilterHintBar", true);
     syncPrefUI();
   });
 }

--- a/src/modules/spotlight/commands.ts
+++ b/src/modules/spotlight/commands.ts
@@ -96,6 +96,10 @@ export class CommandRegistry {
     win: Window,
     limit = 20,
   ): Promise<CommandResult[]> {
+    return this.listAvailable(win, query, limit);
+  }
+
+  listAvailable(win: Window, query = "", limit = 200): CommandResult[] {
     const runContext = this.getRunContext(win);
     const normalizedQuery = normalize(query);
     const results: CommandResult[] = [];

--- a/src/modules/spotlight/palette.ts
+++ b/src/modules/spotlight/palette.ts
@@ -968,13 +968,13 @@ export class PaletteUI {
           },
           {
             label: "Reveal selected result in library",
-            shortcut: "Shift+Enter",
+            shortcut: `${getModifierKeyLabel()}+Enter`,
             detail:
               "Jump the Zotero library selection without breaking the keyboard flow.",
           },
           {
             label: "Alternate open",
-            shortcut: `${getModifierKeyLabel()}+Enter`,
+            shortcut: "Shift+Enter",
             detail: "Use the alternate open behavior for the selected result.",
           },
           {

--- a/src/modules/spotlight/palette.ts
+++ b/src/modules/spotlight/palette.ts
@@ -991,8 +991,127 @@ export class PaletteUI {
           },
         ],
       },
+      {
+        title: "Frequent Zotero",
+        entries: this.getFrequentZoteroShortcuts(),
+      },
+      ...this.collectSpotlightCommandSections(),
       ...this.collectWindowShortcutSections(),
     ];
+  }
+
+  private getFrequentZoteroShortcuts(): ShortcutGuideEntry[] {
+    const modifier = getModifierKeyLabel();
+    const alt = Zotero.isMac ? "Opt" : "Alt";
+    const nextTab = Zotero.isMac ? "Cmd+Shift+]" : "Ctrl+Tab";
+    const previousTab = Zotero.isMac ? "Cmd+Shift+[" : "Ctrl+Shift+Tab";
+    const readerBack = Zotero.isMac ? "Cmd+[" : "Alt+Left";
+    const readerForward = Zotero.isMac ? "Cmd+]" : "Alt+Right";
+    return [
+      {
+        label: "Quick Search in current view",
+        shortcut: `${modifier}+F`,
+        detail:
+          "Focus Zotero's built-in search box for the current library or collection.",
+      },
+      {
+        label: "Quick Search everywhere",
+        shortcut: `${modifier}+Shift+K`,
+        detail: "Jump to Zotero's quick-search field from anywhere in the app.",
+      },
+      {
+        label: "Create new item",
+        shortcut: `${modifier}+Shift+N`,
+        detail: "Add a new bibliographic item by hand.",
+      },
+      {
+        label: "Create new note",
+        shortcut: `${modifier}+Shift+O`,
+        detail: "Create a standalone or child note from the current context.",
+      },
+      {
+        label: "Toggle tag selector",
+        shortcut: `${modifier}+Shift+T`,
+        detail: "Show or hide the tag selector in the Zotero pane.",
+      },
+      {
+        label: "Jump between tabs",
+        shortcut: `${modifier}+1-9`,
+        detail:
+          "Use number keys to switch between the library and open reader tabs.",
+      },
+      {
+        label: "Next tab",
+        shortcut: nextTab,
+        detail: "Move to the next Zotero tab.",
+      },
+      {
+        label: "Previous tab",
+        shortcut: previousTab,
+        detail: "Move to the previous Zotero tab.",
+      },
+      {
+        label: "PDF annotation tools",
+        shortcut: `${alt}+1..4`,
+        detail: "Switch between reader annotation tools inside the PDF view.",
+      },
+      {
+        label: "PDF link back",
+        shortcut: readerBack,
+        detail: "Go back after following an in-PDF link.",
+      },
+      {
+        label: "PDF link forward",
+        shortcut: readerForward,
+        detail: "Go forward after navigating back in a PDF.",
+      },
+    ];
+  }
+
+  private collectSpotlightCommandSections(): ShortcutGuideSection[] {
+    const availableCommands = this.commandRegistry.listAvailable(
+      this.win,
+      "",
+      200,
+    );
+    const externalCommandIDs = new Set(CommandRegistry.listExternalCommands());
+    const builtInEntries = availableCommands
+      .filter(
+        (command) =>
+          !externalCommandIDs.has(command.commandId) && !!command.shortcut,
+      )
+      .map((command) => this.createCommandShortcutEntry(command))
+      .slice(0, 10);
+    const externalEntries = availableCommands
+      .filter(
+        (command) =>
+          externalCommandIDs.has(command.commandId) && !!command.shortcut,
+      )
+      .map((command) => this.createCommandShortcutEntry(command));
+    const sections: ShortcutGuideSection[] = [];
+    if (builtInEntries.length) {
+      sections.push({
+        title: "Spotlight Commands",
+        entries: builtInEntries,
+      });
+    }
+    if (externalEntries.length) {
+      sections.push({
+        title: "Plugin Commands",
+        entries: externalEntries,
+      });
+    }
+    return sections;
+  }
+
+  private createCommandShortcutEntry(
+    command: CommandResult,
+  ): ShortcutGuideEntry {
+    return {
+      label: command.title,
+      shortcut: command.shortcut || "",
+      detail: command.subtitle,
+    };
   }
 
   private collectWindowShortcutSections(): ShortcutGuideSection[] {

--- a/src/modules/spotlight/palette.ts
+++ b/src/modules/spotlight/palette.ts
@@ -50,6 +50,17 @@ type PanelAction = {
   run: () => Promise<void>;
 };
 
+type ShortcutGuideEntry = {
+  label: string;
+  shortcut: string;
+  detail?: string;
+};
+
+type ShortcutGuideSection = {
+  title: string;
+  entries: ShortcutGuideEntry[];
+};
+
 export class PaletteUI {
   private win: Window;
   private doc: Document;
@@ -68,6 +79,7 @@ export class PaletteUI {
   private results: Array<QuickOpenResult | CommandResult | HistoryResult> = [];
   private selectedIndex = 0;
   private panelMode: "preview" | "actions" = "preview";
+  private viewMode: "search" | "shortcuts" = "search";
   private selectedActionIndex = 0;
   private open = false;
   private searchToken = 0;
@@ -161,7 +173,17 @@ export class PaletteUI {
     }
   }
 
+  toggleShortcutGuide(): void {
+    if (this.open && this.viewMode === "shortcuts") {
+      this.hide();
+      return;
+    }
+    this.showShortcutGuide();
+  }
+
   show(): void {
+    this.viewMode = "search";
+    this.input.placeholder = "Spotlight...";
     this.open = true;
     this.root.classList.remove("is-animate");
     this.root.style.display = "block";
@@ -222,10 +244,41 @@ export class PaletteUI {
     this.updateBodyMode();
   }
 
+  showShortcutGuide(): void {
+    this.viewMode = "shortcuts";
+    this.open = true;
+    this.panelMode = "preview";
+    this.selectedActionIndex = 0;
+    this.root.classList.remove("is-animate");
+    this.root.style.display = "block";
+    this.root.classList.add("is-animate");
+    if (this.previewPanel) {
+      this.previewPanel.style.maxHeight = getWindowHeight() + "px";
+    }
+    if (this.root) {
+      this.root.style.width = getWindowWidth() + "px";
+    }
+    this.input.placeholder = "Filter shortcuts...";
+    this.input.value = "";
+    this.closeAutocomplete();
+    this.updateFilterHintBar("");
+    if (this.collectionBar) {
+      this.collectionBar.style.display = "none";
+    }
+    this.renderShortcutGuide("");
+    this.input.focus();
+    this.input.select();
+    this.updateBodyMode();
+  }
+
   hide(): void {
     this.open = false;
-    this._savedQuery = this.input.value;
+    if (this.viewMode !== "shortcuts") {
+      this._savedQuery = this.input.value;
+    }
     this._savedScrollTop = this.list.scrollTop;
+    this.viewMode = "search";
+    this.input.placeholder = "Spotlight...";
     this.root.style.display = "none";
     this.closeAutocomplete();
     this.updateBodyMode();
@@ -241,6 +294,10 @@ export class PaletteUI {
   private bindEvents(): void {
     this.input.addEventListener("input", () => {
       const query = this.input.value;
+      if (this.viewMode === "shortcuts") {
+        this.renderShortcutGuide(query);
+        return;
+      }
       void this.updateResults(query);
       this.updateFilterHintBar(query);
       this.updateAutocomplete(query, this.input.selectionStart ?? query.length);
@@ -257,6 +314,17 @@ export class PaletteUI {
 
   private handleKeydown(event: KeyboardEvent): void {
     if (!this.open) {
+      return;
+    }
+    if (this.viewMode === "shortcuts") {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        this.hide();
+        return;
+      }
+      if (event.key === "Tab") {
+        event.preventDefault();
+      }
       return;
     }
     // Autocomplete interception
@@ -779,6 +847,288 @@ export class PaletteUI {
     this.renderPreview();
   }
 
+  private renderShortcutGuide(query: string): void {
+    if (!this.previewPanel) {
+      return;
+    }
+    const normalizedQuery = normalize(query);
+    const sections = this.getShortcutGuideSections()
+      .map((section) => ({
+        ...section,
+        entries: section.entries.filter((entry) => {
+          if (!normalizedQuery) {
+            return true;
+          }
+          return normalize(
+            `${entry.label} ${entry.shortcut} ${entry.detail || ""}`,
+          ).includes(normalizedQuery);
+        }),
+      }))
+      .filter((section) => section.entries.length);
+
+    this.previewPanel.textContent = "";
+    const container = this.createElement("div", "spotlight-shortcut-guide");
+    const header = this.createElement("div", "spotlight-shortcut-guide-header");
+    const title = this.createElement("div", "spotlight-shortcut-guide-title");
+    title.textContent = "Keyboard Shortcuts";
+    const subtitle = this.createElement(
+      "div",
+      "spotlight-shortcut-guide-subtitle",
+    );
+    subtitle.textContent = normalizedQuery
+      ? `Filtered by "${query.trim()}".`
+      : "A quick-reference page for Spotlight and the current Zotero window.";
+    header.appendChild(title);
+    header.appendChild(subtitle);
+    container.appendChild(header);
+
+    if (!sections.length) {
+      container.appendChild(
+        this.createPreviewEmpty(
+          "No shortcuts matched this filter.",
+          "Try a menu name, action name, or part of the key combination.",
+        ),
+      );
+      this.previewPanel.appendChild(container);
+      return;
+    }
+
+    sections.forEach((section) => {
+      const sectionNode = this.createElement(
+        "div",
+        "spotlight-shortcut-section",
+      );
+      const sectionTitle = this.createElement(
+        "div",
+        "spotlight-shortcut-section-title",
+      );
+      sectionTitle.textContent = section.title;
+      const grid = this.createElement("div", "spotlight-shortcut-grid");
+      section.entries.forEach((entry) => {
+        const card = this.createElement("div", "spotlight-shortcut-card");
+        const cardHeader = this.createElement(
+          "div",
+          "spotlight-shortcut-card-header",
+        );
+        const label = this.createElement("div", "spotlight-shortcut-label");
+        label.textContent = entry.label;
+        const shortcut = this.createElement("div", "spotlight-shortcut-key");
+        shortcut.textContent = entry.shortcut;
+        cardHeader.appendChild(label);
+        cardHeader.appendChild(shortcut);
+        card.appendChild(cardHeader);
+        if (entry.detail) {
+          const detail = this.createElement("div", "spotlight-shortcut-detail");
+          detail.textContent = entry.detail;
+          card.appendChild(detail);
+        }
+        grid.appendChild(card);
+      });
+      sectionNode.appendChild(sectionTitle);
+      sectionNode.appendChild(grid);
+      container.appendChild(sectionNode);
+    });
+
+    this.previewPanel.appendChild(container);
+  }
+
+  private getShortcutGuideSections(): ShortcutGuideSection[] {
+    return [
+      {
+        title: "Spotlight",
+        entries: [
+          {
+            label: "Open Spotlight",
+            shortcut: this.getSpotlightToggleShortcutLabel(),
+            detail:
+              "Open the library-wide switcher from the main window, reader, or notes.",
+          },
+          {
+            label: "Open this shortcuts page",
+            shortcut: `${getModifierKeyLabel()}+/`,
+            detail:
+              "Uses the existing preview surface as a quick-reference page.",
+          },
+          {
+            label: "Open actions / preview",
+            shortcut: "Right Arrow",
+            detail:
+              "Inspect the selected result and switch into the action rail.",
+          },
+          {
+            label: "Back to results",
+            shortcut: "Left Arrow",
+            detail:
+              "Leave the preview action rail and return to the result list.",
+          },
+          {
+            label: "Open selected result",
+            shortcut: "Enter",
+            detail: "Open the selected item, note, attachment, or command.",
+          },
+          {
+            label: "Reveal selected result in library",
+            shortcut: "Shift+Enter",
+            detail:
+              "Jump the Zotero library selection without breaking the keyboard flow.",
+          },
+          {
+            label: "Alternate open",
+            shortcut: `${getModifierKeyLabel()}+Enter`,
+            detail: "Use the alternate open behavior for the selected result.",
+          },
+          {
+            label: "Command mode",
+            shortcut: ">",
+            detail:
+              "Type `>` to search Spotlight commands instead of library items.",
+          },
+          {
+            label: "List open tabs",
+            shortcut: ">tabs",
+            detail:
+              "Jump across currently open Zotero tabs from the same palette.",
+          },
+        ],
+      },
+      ...this.collectWindowShortcutSections(),
+    ];
+  }
+
+  private collectWindowShortcutSections(): ShortcutGuideSection[] {
+    const docs = [this.win.document];
+    const mainDoc = Zotero.getMainWindow()?.document;
+    if (mainDoc && mainDoc !== this.win.document) {
+      docs.push(mainDoc);
+    }
+    const keyMap = new Map<string, string>();
+    docs.forEach((doc) => this.populateKeyMap(doc, keyMap));
+    const sections = new Map<string, ShortcutGuideEntry[]>();
+    const seen = new Set<string>();
+    docs.forEach((doc) => {
+      const items = Array.from(doc.querySelectorAll("menuitem[key]"));
+      items.forEach((node) => {
+        const element = node as Element;
+        if (
+          element.getAttribute("hidden") === "true" ||
+          element.getAttribute("disabled") === "true"
+        ) {
+          return;
+        }
+        const keyRef = element.getAttribute("key");
+        const shortcut = keyRef ? keyMap.get(keyRef) : null;
+        const label = this.getNodeLabel(element);
+        if (!shortcut || !label) {
+          return;
+        }
+        const sectionTitle = this.getTopMenuLabel(element) || "Zotero";
+        const detail = this.getShortcutMenuPath(element, sectionTitle);
+        const dedupeKey = `${sectionTitle}::${label}::${shortcut}`;
+        if (seen.has(dedupeKey)) {
+          return;
+        }
+        seen.add(dedupeKey);
+        const entries = sections.get(sectionTitle) || [];
+        entries.push({ label, shortcut, detail });
+        sections.set(sectionTitle, entries);
+      });
+    });
+    return Array.from(sections.entries())
+      .map(([title, entries]) => ({
+        title,
+        entries: entries
+          .sort((a, b) => a.label.localeCompare(b.label))
+          .slice(0, 14),
+      }))
+      .sort(
+        (a, b) =>
+          this.getShortcutSectionOrder(a.title) -
+          this.getShortcutSectionOrder(b.title),
+      );
+  }
+
+  private populateKeyMap(
+    doc: Document,
+    destination: Map<string, string>,
+  ): void {
+    Array.from(doc.querySelectorAll("key[id]")).forEach((node) => {
+      const element = node as Element;
+      const id = element.getAttribute("id");
+      if (!id || destination.has(id)) {
+        return;
+      }
+      const shortcut = formatKeyElementShortcut(element);
+      if (shortcut) {
+        destination.set(id, shortcut);
+      }
+    });
+  }
+
+  private getNodeLabel(node: Element): string {
+    const raw =
+      node.getAttribute("label") ||
+      (node as any).label ||
+      node.getAttribute("aria-label") ||
+      "";
+    return String(raw).replace(/\s+/g, " ").trim();
+  }
+
+  private getTopMenuLabel(node: Element): string {
+    let current: Element | null = node.parentElement;
+    let topMenuLabel = "";
+    while (current) {
+      if (current.localName === "menu") {
+        const label = this.getNodeLabel(current);
+        if (label) {
+          topMenuLabel = label;
+        }
+      }
+      current = current.parentElement;
+    }
+    return topMenuLabel;
+  }
+
+  private getShortcutMenuPath(node: Element, sectionTitle: string): string {
+    const trail: string[] = [];
+    let current: Element | null = node.parentElement;
+    while (current) {
+      if (current.localName === "menu") {
+        const label = this.getNodeLabel(current);
+        if (label && label !== sectionTitle) {
+          trail.unshift(label);
+        }
+      }
+      current = current.parentElement;
+    }
+    return trail.length ? trail.join(" > ") : "Current window";
+  }
+
+  private getShortcutSectionOrder(title: string): number {
+    const normalized = title.toLowerCase();
+    const order = [
+      "file",
+      "edit",
+      "view",
+      "go",
+      "item",
+      "tools",
+      "reader",
+      "help",
+      "zotero",
+    ];
+    const index = order.indexOf(normalized);
+    return index >= 0 ? index : order.length + normalized.charCodeAt(0);
+  }
+
+  private getSpotlightToggleShortcutLabel(): string {
+    const modifier = getModifierKeyLabel();
+    const shortcutMode = (getPref("shortcutMode") || "primary") as string;
+    if (shortcutMode === "fallback") {
+      return `${modifier}+Shift+P`;
+    }
+    return `${modifier}+P`;
+  }
+
   private createRoot(): HTMLDivElement {
     const root = this.createElement("div", "spotlight-root") as HTMLDivElement;
     root.id = "zotero-spotlight-root";
@@ -968,6 +1318,17 @@ export class PaletteUI {
 
 .spotlight-body.is-panel-open #zotero-spotlight-preview-panel {
   display: block;
+}
+
+#zotero-spotlight-root.is-shortcut-guide #zotero-spotlight-filter-hint-bar,
+#zotero-spotlight-root.is-shortcut-guide .spotlight-list-pane,
+#zotero-spotlight-root.is-shortcut-guide #zotero-spotlight-collection-bar {
+  display: none !important;
+}
+
+#zotero-spotlight-root.is-shortcut-guide #zotero-spotlight-preview-panel {
+  display: block;
+  min-height: 360px;
 }
 
 .spotlight-result {
@@ -1190,6 +1551,92 @@ export class PaletteUI {
   height: 8px;
   border-radius: 999px;
   flex: 0 0 auto;
+}
+
+.spotlight-shortcut-guide {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.spotlight-shortcut-guide-header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-bottom: 2px;
+  border-bottom: 1px solid var(--quick-open-border);
+}
+
+.spotlight-shortcut-guide-title {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--quick-open-text);
+}
+
+.spotlight-shortcut-guide-subtitle {
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--quick-open-subtext);
+}
+
+.spotlight-shortcut-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.spotlight-shortcut-section-title {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--quick-open-subtext);
+}
+
+.spotlight-shortcut-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 8px;
+}
+
+.spotlight-shortcut-card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 12px;
+  border: 1px solid var(--quick-open-border);
+  border-radius: 10px;
+  background: var(--quick-open-bg);
+}
+
+.spotlight-shortcut-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.spotlight-shortcut-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--quick-open-text);
+}
+
+.spotlight-shortcut-key {
+  flex-shrink: 0;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--quick-open-meta-chip-bg);
+  color: var(--quick-open-meta-chip-text);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.spotlight-shortcut-detail {
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--quick-open-subtext);
 }
 
 @media (max-width: 760px) {
@@ -1465,10 +1912,21 @@ export class PaletteUI {
     if (!this.body) {
       return;
     }
-    this.body.classList.toggle("is-panel-open", this.panelMode === "actions");
+    const previewVisible =
+      this.panelMode === "actions" || this.viewMode === "shortcuts";
+    this.body.classList.toggle("is-panel-open", previewVisible);
+    this.root.classList.toggle(
+      "is-shortcut-guide",
+      this.viewMode === "shortcuts",
+    );
     if (this.previewModeHeader) {
-      this.previewModeHeader.style.display =
-        this.panelMode === "actions" ? "block" : "none";
+      this.previewModeHeader.style.display = previewVisible ? "block" : "none";
+      this.previewModeHeader.textContent =
+        this.viewMode === "shortcuts"
+          ? "Shortcut Guide"
+          : this.panelMode === "actions"
+            ? "Preview"
+            : "";
     }
   }
 
@@ -3263,4 +3721,78 @@ function getWindowWidth(): number {
   const raw = Number((getPref as any)("windowWidth"));
   if (Number.isNaN(raw) || raw <= 0) return 560;
   return Math.min(1200, Math.max(300, raw));
+}
+
+function getModifierKeyLabel(): string {
+  return Zotero.isMac ? "Cmd" : "Ctrl";
+}
+
+function normalize(value: string): string {
+  return value.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function formatKeyElementShortcut(element: Element): string {
+  const modifiers = String(element.getAttribute("modifiers") || "")
+    .split(/[,\s]+/)
+    .map((part) => part.trim().toLowerCase())
+    .filter(Boolean)
+    .map((part) => {
+      if (part === "accel") {
+        return getModifierKeyLabel();
+      }
+      if (part === "meta") {
+        return "Cmd";
+      }
+      if (part === "control" || part === "ctrl") {
+        return "Ctrl";
+      }
+      if (part === "alt") {
+        return Zotero.isMac ? "Opt" : "Alt";
+      }
+      if (part === "shift") {
+        return "Shift";
+      }
+      return part.charAt(0).toUpperCase() + part.slice(1);
+    });
+  const key =
+    element.getAttribute("key") ||
+    normalizeKeycode(String(element.getAttribute("keycode") || ""));
+  const normalizedKey = String(key || "").trim();
+  if (!normalizedKey) {
+    return "";
+  }
+  return [...modifiers, normalizedKey].join("+");
+}
+
+function normalizeKeycode(value: string): string {
+  const normalized = value.replace(/^VK_/, "");
+  const namedKeys: Record<string, string> = {
+    RETURN: "Enter",
+    ENTER: "Enter",
+    ESCAPE: "Esc",
+    DELETE: "Delete",
+    BACK: "Backspace",
+    BACK_SPACE: "Backspace",
+    SPACE: "Space",
+    TAB: "Tab",
+    PAGE_UP: "PgUp",
+    PAGE_DOWN: "PgDn",
+    UP: "Up",
+    DOWN: "Down",
+    LEFT: "Left",
+    RIGHT: "Right",
+    HOME: "Home",
+    END: "End",
+  };
+  if (namedKeys[normalized]) {
+    return namedKeys[normalized];
+  }
+  return normalized
+    .split("_")
+    .map((part) =>
+      part.length <= 1
+        ? part.toUpperCase()
+        : part.charAt(0) + part.slice(1).toLowerCase(),
+    )
+    .join(" ");
 }

--- a/src/modules/spotlight/palette.ts
+++ b/src/modules/spotlight/palette.ts
@@ -3720,7 +3720,9 @@ export class PaletteUI {
 
   private updateFilterHintBar(query: string): void {
     if (!this.filterHintBar) return;
-    this.filterHintBar.style.display = query.trim() === "" ? "flex" : "none";
+    const enabled = (getPref as any)("showFilterHintBar");
+    const show = (enabled === undefined || enabled === null ? true : !!enabled) && query.trim() === "";
+    this.filterHintBar.style.display = show ? "flex" : "none";
   }
 
   // ── Colon-triggered autocomplete (Option A) ────────────────────────────────

--- a/src/modules/spotlight/palette.ts
+++ b/src/modules/spotlight/palette.ts
@@ -1896,6 +1896,17 @@ export class PaletteUI {
   border-color: var(--quick-open-border-soft);
 }
 
+.spotlight-shortcut-guide-btn {
+  font-family: inherit;
+  font-size: 14px;
+  padding: 0;
+  width: 22px;
+  height: 22px;
+  justify-content: center;
+  line-height: 1;
+  padding-bottom: 2px;
+}
+
 .spotlight-autocomplete {
   margin-top: 4px;
   background: var(--quick-open-input-bg);
@@ -3691,6 +3702,20 @@ export class PaletteUI {
         "Switch to command mode\nExample: > Open Tab by URL",
       ),
     );
+
+    // ── Shortcut guide button ────────────────────────────────────────────────
+    const shortcutBtn = this.createElement(
+      "button",
+      "spotlight-filter-hint-badge spotlight-shortcut-guide-btn",
+    ) as HTMLButtonElement;
+    shortcutBtn.textContent = "⌨";
+    shortcutBtn.title = `Keyboard shortcuts (${getModifierKeyLabel()}+/)`;
+    shortcutBtn.style.marginLeft = "auto";
+    shortcutBtn.addEventListener("mousedown", (e) => {
+      e.preventDefault();
+      this.toggleShortcutGuide();
+    });
+    this.filterHintBar.appendChild(shortcutBtn);
   }
 
   private updateFilterHintBar(query: string): void {

--- a/src/modules/spotlight/windowManager.ts
+++ b/src/modules/spotlight/windowManager.ts
@@ -41,6 +41,12 @@ export class WindowManager {
     }
     const palette = new PaletteUI(win, this.searchService, new ActionHandler());
     const handler = (event: KeyboardEvent) => {
+      if (isShortcutGuideEvent(event)) {
+        event.preventDefault();
+        event.stopPropagation();
+        palette.toggleShortcutGuide();
+        return;
+      }
       if (!isToggleEvent(event)) {
         return;
       }
@@ -178,4 +184,16 @@ function isToggleEvent(event: KeyboardEvent): boolean {
     return !event.shiftKey;
   }
   return true;
+}
+
+function isShortcutGuideEvent(event: KeyboardEvent): boolean {
+  if (event.altKey || event.shiftKey) {
+    return false;
+  }
+  const modifier = Zotero.isMac ? event.metaKey : event.ctrlKey;
+  if (!modifier) {
+    return false;
+  }
+  const key = event.key?.toLowerCase();
+  return key === "/" || event.code === "Slash";
 }

--- a/typings/i10n.d.ts
+++ b/typings/i10n.d.ts
@@ -22,6 +22,7 @@ export type FluentMessageId =
   | 'pref-shortcut-fallback'
   | 'pref-shortcut-primary'
   | 'pref-shortcut-section'
+  | 'pref-show-filter-hint-bar'
   | 'pref-window-height'
   | 'pref-window-section'
   | 'pref-window-width'


### PR DESCRIPTION
## Summary

- Adds a full keyboard shortcut reference overlay, opened with `Cmd+/` (`Ctrl+/` on Windows/Linux) — uses the existing preview surface as a searchable/filterable reference page
- Adds a keyboard icon button to the filter hint bar to open the shortcut guide from the mouse
- Adds a preference setting to toggle filter hint bar visibility
- Fixes swapped `Shift+Enter` / `Cmd+Enter` shortcuts in the guide after a rebase onto main
- Updates README with correct filter sigils (`:pdf`, `#tag`, `y:`), `=phrase` PDF fulltext search, filter hint bar, right-click action panel, best attachment badge, and `>add note + open best attachment` command

## Test plan

- [ ] Press `Cmd+/` (or `Ctrl+/`) from the main window, reader, and note editor — shortcut guide opens
- [ ] Guide is searchable/filterable by typing in the input
- [ ] Press `Cmd+/` again while guide is open — closes
- [ ] Keyboard icon button in filter hint bar opens the guide
- [ ] Preferences setting toggles filter hint bar visibility
- [ ] `Shift+Enter` reveals item in library; `Cmd/Ctrl+Enter` uses alternate open

🤖 Generated with [Claude Code](https://claude.com/claude-code)