### PR TITLE
Fix arrow-key navigation in Spotlight search

### DIFF
--- a/src/modules/spotlight/palette.ts
+++ b/src/modules/spotlight/palette.ts
@@ -370,6 +370,7 @@ export class PaletteUI {
     }
     if (event.key === "Tab") {
       event.preventDefault();
+      this.openActionsPanel();
       return;
     }
     if (event.key === "Escape") {
@@ -379,18 +380,6 @@ export class PaletteUI {
         return;
       }
       this.hide();
-      return;
-    }
-    if (event.key === "ArrowRight") {
-      event.preventDefault();
-      this.openActionsPanel();
-      return;
-    }
-    if (event.key === "ArrowLeft") {
-      if (this.panelMode === "actions") {
-        event.preventDefault();
-        this.closeActionsPanel();
-      }
       return;
     }
     if (event.key === "ArrowDown") {


### PR DESCRIPTION
## Summary

- preserve Left and Right arrow keys for normal cursor movement in the search input
- open contextual item actions with `Tab`
- keep `Escape` as the way to close the expanded actions view

## Why

Spotlight previously bound the Right Arrow key to the actions panel, preventing users from moving the text cursor to the right while editing a search query.

Closes #35.

## Validation

- `npm run lint:check`
- `npm run build`