### PR TITLE
Add searchable actions and synced reading queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,12 @@ Spotlight is different:
 - Trigger context-aware commands based on the current Zotero window and selected item.
 - Let other Zotero plugins register commands into Spotlight through the command API.
 
-### 3. Future Direction: AI Commands
+### 3. Synced Reading Queue
 
-- Spotlight is designed to grow toward intent-driven AI commands, closer to a Zotero-native Raycast-style command surface.
-- Likely future directions include paper summarization, annotation synthesis, note drafting, and paper-to-note comparison workflows.
-- This layer is planned, not shipped yet.
+- Add any paper to a deliberate read-later queue from its `Tab` action menu or with `> Add to Reading Queue`.
+- Type `:queue` to see queued papers, optionally combined with text, type, tag, or year filters.
+- Remove a paper from the queue when it is handled with `> Remove from Reading Queue`.
+- Queue state is stored as a normal `📚 Reading Queue` Zotero tag, so it syncs across devices and remains visible and portable outside Spotlight.
 
 ## Contributing
 

--- a/doc/roadmap.md
+++ b/doc/roadmap.md
@@ -54,8 +54,14 @@ Zotero Spotlight aims to become a universal command surface inside Zotero: avail
 - [x] Expose a command API so other Zotero plugins can register Spotlight actions
 - [x] Grow Spotlight into a shared command surface for the wider plugin ecosystem
 
+## Phase 10 — Synced Reading Queue
+
+- [x] Add or remove the active paper from a keyboard-first reading queue
+- [x] Filter queued papers with `:queue`, including combinations such as `:queue :pdf y:2026`
+- [x] Store queue state as a portable Zotero tag so it syncs without a separate service
+
 ## Future Directions
 
-- AI-assisted commands for summarization, note drafting, and paper comparison
+- Deeper reading-status and review workflows built on the Reading Queue
 - Better onboarding for filters and advanced search syntax
 - Deeper integrations with other Zotero plugins through the command API

--- a/src/modules/spotlight/commands.ts
+++ b/src/modules/spotlight/commands.ts
@@ -8,6 +8,11 @@ import {
   getParentForCommand,
   isOpenableAttachment,
 } from "./attachmentHelpers";
+import {
+  getReadingQueueTarget,
+  isInReadingQueue,
+  setReadingQueueState,
+} from "./readingQueue";
 
 export type CommandContext = "main" | "reader" | "note";
 
@@ -161,12 +166,13 @@ export class CommandRegistry {
   private getRunContext(win: Window): CommandRunContext {
     const mainWindow = Zotero.getMainWindow() || null;
     const pane = this.getPane(mainWindow);
+    const context = detectCommandContext(win);
     return {
       win,
       pane,
       mainWindow,
-      context: detectCommandContext(win),
-      activeItem: this.getActiveItem(win, pane),
+      context,
+      activeItem: this.getActiveItem(win, pane, context),
     };
   }
 
@@ -187,7 +193,17 @@ export class CommandRegistry {
   private getActiveItem(
     win: Window,
     pane: _ZoteroTypes.ZoteroPane | null,
+    context: CommandContext,
   ): Zotero.Item | null {
+    if (context !== "main") {
+      const tabItemID = getActiveTabItemID(win);
+      if (tabItemID) {
+        const tabItem = Zotero.Items.get(tabItemID) as Zotero.Item;
+        if (tabItem) {
+          return tabItem;
+        }
+      }
+    }
     const selectedItem = pane?.getSelectedItems?.()?.[0] as
       Zotero.Item | undefined;
     if (selectedItem) {
@@ -205,6 +221,45 @@ export class CommandRegistry {
 
   private createBuiltInCommands(): SpotlightCommand[] {
     return [
+      {
+        id: "add-to-reading-queue",
+        title: "Add to Reading Queue",
+        subtitle: "Save the current paper to your synced reading queue",
+        keywords: ["read later", "inbox", "queue", "save paper"],
+        contexts: ["main", "reader", "note"],
+        icon: "collection",
+        group: "Reading",
+        isAvailable: ({ activeItem }) => ({
+          enabled:
+            !!getReadingQueueTarget(activeItem) &&
+            !isInReadingQueue(activeItem),
+          reason: "Select a paper that is not already queued",
+        }),
+        run: async ({ activeItem }) => {
+          if (activeItem) {
+            await setReadingQueueState(activeItem, true);
+          }
+        },
+      },
+      {
+        id: "remove-from-reading-queue",
+        title: "Remove from Reading Queue",
+        subtitle: "Mark the current paper as handled",
+        keywords: ["read", "done", "complete", "queue"],
+        contexts: ["main", "reader", "note"],
+        icon: "collection",
+        group: "Reading",
+        isAvailable: ({ activeItem }) => ({
+          enabled:
+            !!getReadingQueueTarget(activeItem) && isInReadingQueue(activeItem),
+          reason: "Select a paper in the reading queue",
+        }),
+        run: async ({ activeItem }) => {
+          if (activeItem) {
+            await setReadingQueueState(activeItem, false);
+          }
+        },
+      },
       {
         id: "new-note",
         title: "New Note",

--- a/src/modules/spotlight/palette.ts
+++ b/src/modules/spotlight/palette.ts
@@ -81,6 +81,8 @@ export class PaletteUI {
   private panelMode: "preview" | "actions" = "preview";
   private viewMode: "search" | "shortcuts" = "search";
   private selectedActionIndex = 0;
+  private actionQuery = "";
+  private actionInput: HTMLInputElement | null = null;
   private open = false;
   private searchToken = 0;
   private outsideClickHandler: (event: MouseEvent) => void;
@@ -207,6 +209,8 @@ export class PaletteUI {
     this.selectedIndex = 0;
     this.panelMode = "preview";
     this.selectedActionIndex = 0;
+    this.actionQuery = "";
+    this.actionInput = null;
     // Detect active collection for folder-scoped search
     this._activeCollection = null;
     try {
@@ -316,6 +320,43 @@ export class PaletteUI {
     if (!this.open) {
       return;
     }
+    if (this.panelMode === "actions") {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        if (this.actionQuery) {
+          this.actionQuery = "";
+          this.selectedActionIndex = 0;
+          this.renderPreview();
+          this.focusActionInput();
+        } else {
+          this.closeActionsPanel();
+        }
+        return;
+      }
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        this.moveActionSelection(1);
+        return;
+      }
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        this.moveActionSelection(-1);
+        return;
+      }
+      if (event.key === "Enter") {
+        event.preventDefault();
+        void this.activateSelectedPanelAction();
+        return;
+      }
+      if (event.key === "Tab") {
+        event.preventDefault();
+        this.focusActionInput();
+        return;
+      }
+      if (event.target === this.actionInput) {
+        return;
+      }
+    }
     if (this.viewMode === "shortcuts") {
       if (event.key === "Escape") {
         event.preventDefault();
@@ -371,6 +412,17 @@ export class PaletteUI {
     if (event.key === "Tab") {
       event.preventDefault();
       this.openActionsPanel();
+      return;
+    }
+    if (
+      event.ctrlKey &&
+      !event.metaKey &&
+      !event.altKey &&
+      this.displayMode === "search" &&
+      /^[1-9]$/.test(event.key)
+    ) {
+      event.preventDefault();
+      this.activateVisibleResult(Number(event.key) - 1);
       return;
     }
     if (event.key === "Escape") {
@@ -493,6 +545,8 @@ export class PaletteUI {
     await this.markBestAttachmentBadges(this.results);
     if (token !== this.searchToken) return;
     this.panelMode = "preview";
+    this.actionQuery = "";
+    this.actionInput = null;
     this.selectedActionIndex = 0;
     this.updateBodyMode();
     this.sectionHeader = parsedQuery.isCommandMode
@@ -542,7 +596,7 @@ export class PaletteUI {
   }
 
   private moveActionSelection(delta: number): void {
-    const actions = this.getPanelActions();
+    const actions = this.getFilteredPanelActions();
     if (!actions.length) {
       return;
     }
@@ -552,9 +606,14 @@ export class PaletteUI {
       Math.min(maxIndex, this.selectedActionIndex + delta),
     );
     this.renderPreview();
+    this.focusActionInput();
   }
 
   private openActionsPanel(): void {
+    if (this.panelMode === "actions") {
+      this.focusActionInput();
+      return;
+    }
     if (!this.results.length) {
       return;
     }
@@ -563,28 +622,51 @@ export class PaletteUI {
       return;
     }
     this.panelMode = "actions";
+    this.actionQuery = "";
     this.selectedActionIndex = Math.max(
       0,
       Math.min(actions.length - 1, this.selectedActionIndex),
     );
     this.updateBodyMode();
+    this.closeAutocomplete();
     this.renderPreview();
+    this.focusActionInput();
   }
 
   private closeActionsPanel(): void {
     this.panelMode = "preview";
+    this.actionQuery = "";
+    this.actionInput = null;
     this.selectedActionIndex = 0;
     this.updateBodyMode();
     this.renderPreview();
+    this.input.focus();
   }
 
   private async activateSelectedPanelAction(): Promise<void> {
-    const actions = this.getPanelActions();
+    const actions = this.getFilteredPanelActions();
     const action = actions[this.selectedActionIndex];
     if (!action) {
       return;
     }
     await action.run();
+  }
+
+  private activateVisibleResult(position: number): void {
+    const rows = Array.from(
+      this.list.querySelectorAll(".spotlight-result"),
+    ) as HTMLElement[];
+    const row = rows[position];
+    if (!row) {
+      return;
+    }
+    const resultIndex = Number(row.dataset.resultIndex);
+    if (!Number.isInteger(resultIndex)) {
+      return;
+    }
+    this.selectedIndex = resultIndex;
+    this.updateSelectionState();
+    void this.activateSelection("default");
   }
 
   private async activateSelection(intent: OpenIntent): Promise<void> {
@@ -715,6 +797,7 @@ export class PaletteUI {
       (r) => r.kind === "annotation",
     ).length;
     let lastSectionKind: string | null = null;
+    let visibleResultPosition = 0;
 
     this.results.forEach((result, index) => {
       // Insert section header when category changes
@@ -769,7 +852,15 @@ export class PaletteUI {
       const isOpenTab =
         (result.kind === "item" || result.kind === "attachment") &&
         openTabItemIDs.has(result.id);
-      this.appendResultBadges(row, result, isOpenTab);
+      this.appendResultBadges(
+        row,
+        result,
+        isOpenTab,
+        this.displayMode === "search" && visibleResultPosition < 9
+          ? visibleResultPosition + 1
+          : null,
+      );
+      visibleResultPosition += 1;
       if (result.kind === "history") {
         const deleteButton = this.createElement(
           "button",
@@ -939,16 +1030,22 @@ export class PaletteUI {
               "Uses the existing preview surface as a quick-reference page.",
           },
           {
-            label: "Open actions / preview",
-            shortcut: "Right Arrow",
+            label: "Open contextual actions",
+            shortcut: "Tab",
             detail:
-              "Inspect the selected result and switch into the action rail.",
+              "Inspect the selected result and search actions that apply to it.",
           },
           {
             label: "Back to results",
-            shortcut: "Left Arrow",
+            shortcut: "Escape",
             detail:
-              "Leave the preview action rail and return to the result list.",
+              "Clear an action filter first, then return to the result list.",
+          },
+          {
+            label: "Quick-open a visible result",
+            shortcut: "Ctrl+1-9",
+            detail:
+              "Open one of the first nine numbered search results directly.",
           },
           {
             label: "Open selected result",
@@ -1577,6 +1674,41 @@ export class PaletteUI {
   align-self: stretch;
 }
 
+.spotlight-action-search {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-bottom: 10px;
+  padding: 6px 8px;
+  border: 1px solid var(--quick-open-border);
+  border-radius: 7px;
+  background: var(--quick-open-input-bg);
+}
+
+.spotlight-action-search:focus-within {
+  border-color: var(--quick-open-border-focus);
+  box-shadow: 0 0 0 2px var(--quick-open-focus-ring);
+}
+
+.spotlight-action-search-prefix {
+  color: var(--quick-open-command-icon-text);
+  font-size: 13px;
+  font-weight: 700;
+  user-select: none;
+}
+
+.spotlight-action-search-input {
+  width: 100%;
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  outline: none;
+  background: transparent;
+  color: var(--quick-open-text);
+  font: inherit;
+  font-size: 12px;
+}
+
 .spotlight-preview-detail {
   min-width: 0;
 }
@@ -1586,6 +1718,12 @@ export class PaletteUI {
   flex-direction: column;
   gap: 6px;
   margin-top: 0;
+}
+
+.spotlight-action-empty {
+  padding: 8px 9px;
+  color: var(--quick-open-muted);
+  font-size: 12px;
 }
 
 .spotlight-action-item {
@@ -1801,6 +1939,14 @@ export class PaletteUI {
   border-radius: 999px;
   padding: 3px 6px;
   flex: 0 0 auto;
+}
+
+.spotlight-quick-open-tag {
+  border: 1px solid var(--quick-open-border-soft);
+  background: var(--quick-open-input-bg);
+  color: var(--quick-open-subtext);
+  letter-spacing: 0;
+  text-transform: none;
 }
 
 .spotlight-tab-dot {
@@ -2044,7 +2190,7 @@ export class PaletteUI {
         this.viewMode === "shortcuts"
           ? "Shortcut Guide"
           : this.panelMode === "actions"
-            ? "Preview"
+            ? "Actions"
             : "";
     }
   }
@@ -2344,11 +2490,9 @@ export class PaletteUI {
       "spotlight-preview-detail",
     );
     if (this.panelMode === "actions") {
-      const actions = this.getPanelActions();
-      if (actions.length) {
-        shell.classList.add("is-actions-mode");
-        shell.appendChild(this.createActionsPanel(actions));
-      }
+      const actions = this.getFilteredPanelActions();
+      shell.classList.add("is-actions-mode");
+      shell.appendChild(this.createActionsPanel(actions));
     }
     if (result.kind === "history") {
       this.renderHistoryPreview(detailContainer, result as HistoryResult);
@@ -2484,7 +2628,35 @@ export class PaletteUI {
 
   private createActionsPanel(actions: PanelAction[]): HTMLElement {
     const panel = this.createElement("div", "spotlight-actions-panel");
+    const search = this.createElement("div", "spotlight-action-search");
+    const prefix = this.createElement("span", "spotlight-action-search-prefix");
+    prefix.textContent = ">";
+    prefix.setAttribute("aria-hidden", "true");
+    const input = this.createElement(
+      "input",
+      "spotlight-action-search-input",
+    ) as HTMLInputElement;
+    input.type = "text";
+    input.value = this.actionQuery;
+    input.placeholder = "Type an action...";
+    input.setAttribute("aria-label", "Filter actions");
+    input.addEventListener("input", () => {
+      this.actionQuery = input.value;
+      this.selectedActionIndex = 0;
+      this.renderPreview();
+      this.focusActionInput();
+    });
+    search.appendChild(prefix);
+    search.appendChild(input);
+    panel.appendChild(search);
+    this.actionInput = input;
+
     const list = this.createElement("div", "spotlight-action-list");
+    if (!actions.length) {
+      const empty = this.createElement("div", "spotlight-action-empty");
+      empty.textContent = "No matching actions";
+      list.appendChild(empty);
+    }
     actions.forEach((action, index) => {
       const button = this.createElement(
         "button",
@@ -2504,8 +2676,8 @@ export class PaletteUI {
       button.appendChild(title);
       button.addEventListener("mouseenter", () => {
         this.selectedActionIndex = index;
-        this.input.focus();
         this.renderPreview();
+        this.focusActionInput();
       });
       button.addEventListener("click", () => {
         void action.run();
@@ -2514,6 +2686,19 @@ export class PaletteUI {
     });
     panel.appendChild(list);
     return panel;
+  }
+
+  private focusActionInput(): void {
+    const input = this.previewPanel.querySelector(
+      ".spotlight-action-search-input",
+    ) as HTMLInputElement | null;
+    if (!input) {
+      return;
+    }
+    this.actionInput = input;
+    input.focus();
+    const end = input.value.length;
+    input.setSelectionRange(end, end);
   }
 
   private createPreviewEmpty(message: string, detail: string): HTMLElement {
@@ -2834,6 +3019,21 @@ export class PaletteUI {
     }
 
     return actions;
+  }
+
+  private getFilteredPanelActions(): PanelAction[] {
+    const actions = this.getPanelActions();
+    const query = normalize(this.actionQuery);
+    if (!query) {
+      return actions;
+    }
+    const terms = query.split(/\s+/).filter(Boolean);
+    return actions.filter((action) => {
+      const searchable = normalize(
+        `${action.label} ${action.hint || ""} ${action.id}`,
+      );
+      return terms.every((term) => searchable.includes(term));
+    });
   }
 
   private createOpenAttachmentPanelAction(
@@ -3469,7 +3669,21 @@ export class PaletteUI {
     row: HTMLElement,
     result: QuickOpenResult | CommandResult | HistoryResult,
     isOpenTab: boolean,
+    quickOpenNumber: number | null,
   ): void {
+    if (quickOpenNumber !== null) {
+      const quickOpenTag = this.createElement(
+        "span",
+        "spotlight-tag spotlight-quick-open-tag",
+      );
+      quickOpenTag.textContent = `${Zotero.isMac ? "⌃" : "Ctrl+"}${quickOpenNumber}`;
+      quickOpenTag.title = `Open result ${quickOpenNumber}`;
+      quickOpenTag.setAttribute(
+        "aria-label",
+        `Control plus ${quickOpenNumber}: open result`,
+      );
+      row.appendChild(quickOpenTag);
+    }
     if (result.kind === "history") {
       const historyTag = this.createElement("span", "spotlight-tag");
       historyTag.textContent = "HISTORY";

--- a/src/modules/spotlight/palette.ts
+++ b/src/modules/spotlight/palette.ts
@@ -27,6 +27,12 @@ import {
   isOpenableAttachmentType,
 } from "./attachmentHelpers";
 import { getPref } from "../../utils/prefs";
+import {
+  getReadingQueueTarget,
+  isInReadingQueue,
+  NORMALIZED_READING_QUEUE_TAG,
+  setReadingQueueState,
+} from "./readingQueue";
 
 const HTML_NS = "http://www.w3.org/1999/xhtml";
 
@@ -2926,6 +2932,10 @@ export class PaletteUI {
       if (copyAction) {
         actions.push(copyAction);
       }
+      const queueAction = this.createReadingQueuePanelAction(result);
+      if (queueAction) {
+        actions.push(queueAction);
+      }
       return actions.filter((action) =>
         action.id === "reveal-attachment"
           ? typeof result.attachmentID === "number"
@@ -3018,7 +3028,35 @@ export class PaletteUI {
       actions.push(copyAction);
     }
 
+    const queueAction = this.createReadingQueuePanelAction(result);
+    if (queueAction) {
+      actions.push(queueAction);
+    }
+
     return actions;
+  }
+
+  private createReadingQueuePanelAction(
+    result: QuickOpenResult,
+  ): PanelAction | null {
+    const item = Zotero.Items.get(result.id) as Zotero.Item | null;
+    const target = getReadingQueueTarget(item);
+    if (!item || !target) {
+      return null;
+    }
+    const queued = isInReadingQueue(target);
+    return {
+      id: queued ? "remove-from-reading-queue" : "add-to-reading-queue",
+      label: queued ? "Remove from Reading Queue" : "Add to Reading Queue",
+      icon: this.getActionCommandIcon("collection", queued ? "✓" : "+"),
+      hint: queued
+        ? "Mark this paper as handled"
+        : "Save this paper to the synced :queue view",
+      run: async () => {
+        await setReadingQueueState(target, !queued);
+        this.hide();
+      },
+    };
   }
 
   private getFilteredPanelActions(): PanelAction[] {
@@ -3712,6 +3750,11 @@ export class PaletteUI {
     if ((result as QuickOpenResult).libraryKind === "group") {
       badges.push("GROUP");
     }
+    if (
+      (result as QuickOpenResult).tags?.includes(NORMALIZED_READING_QUEUE_TAG)
+    ) {
+      badges.push("QUEUE");
+    }
 
     const isBestAttachment =
       result.kind === "attachment" &&
@@ -3841,6 +3884,11 @@ export class PaletteUI {
     const filterHints: Array<{ label: string; insert: string; title: string }> =
       [
         {
+          label: ":queue",
+          insert: ":queue ",
+          title: "Show papers saved to your Reading Queue",
+        },
+        {
           label: ":pdf",
           insert: ":pdf ",
           title: "Filter to PDF attachments only\nExample: :pdf Einstein",
@@ -3957,6 +4005,7 @@ export class PaletteUI {
       return;
     }
     const typeValues = [
+      "queue",
       "pdf",
       "epub",
       "snapshot",

--- a/src/modules/spotlight/readingQueue.ts
+++ b/src/modules/spotlight/readingQueue.ts
@@ -1,0 +1,62 @@
+export const READING_QUEUE_TAG = "📚 Reading Queue";
+export const NORMALIZED_READING_QUEUE_TAG = READING_QUEUE_TAG.toLowerCase();
+
+export function getReadingQueueTarget(
+  item: Zotero.Item | null,
+): Zotero.Item | null {
+  let current = item;
+  const visited = new Set<number>();
+
+  while (current && !visited.has(current.id)) {
+    visited.add(current.id);
+    if (current.isRegularItem?.()) {
+      return current;
+    }
+    const parentID = (current as any).parentID ?? (current as any).parentItemID;
+    if (typeof parentID !== "number") {
+      return null;
+    }
+    current = (Zotero.Items.get(parentID) as Zotero.Item | null) || null;
+  }
+
+  return null;
+}
+
+export function isInReadingQueue(item: Zotero.Item | null): boolean {
+  const target = getReadingQueueTarget(item);
+  if (!target) {
+    return false;
+  }
+  return getExistingQueueTag(target) !== null;
+}
+
+export async function setReadingQueueState(
+  item: Zotero.Item,
+  queued: boolean,
+): Promise<Zotero.Item | null> {
+  const target = getReadingQueueTarget(item);
+  if (!target) {
+    return null;
+  }
+
+  const existingTag = getExistingQueueTag(target);
+  if (queued && !existingTag) {
+    target.addTag(READING_QUEUE_TAG);
+  } else if (!queued && existingTag) {
+    target.removeTag(existingTag);
+  } else {
+    return target;
+  }
+  await target.saveTx();
+  return target;
+}
+
+function getExistingQueueTag(item: Zotero.Item): string | null {
+  for (const entry of item.getTags?.() || []) {
+    const tag = typeof entry === "string" ? entry : entry.tag || "";
+    if (tag.trim().toLowerCase() === NORMALIZED_READING_QUEUE_TAG) {
+      return tag;
+    }
+  }
+  return null;
+}

--- a/src/modules/spotlight/search.ts
+++ b/src/modules/spotlight/search.ts
@@ -8,6 +8,7 @@ import {
   getItemYearSafe,
 } from "./itemMetadata";
 import { getPref } from "../../utils/prefs";
+import { NORMALIZED_READING_QUEUE_TAG } from "./readingQueue";
 
 export type QuickOpenResult = ItemResult | AttachmentResult | AnnotationResult;
 
@@ -83,6 +84,7 @@ type ParsedQuery = {
   filters: {
     types: Set<ResultType>;
     tags: string[];
+    readingQueue: boolean;
     yearMin?: number;
     yearMax?: number;
   };
@@ -511,7 +513,7 @@ async function buildAnnotationIndex(): Promise<IndexedEntry[]> {
   const parentItemCache = new Map<number, Zotero.Item | null>();
   const parentMetaCache = new Map<
     number,
-    { title: string; authors: string; year: number | null }
+    { title: string; authors: string; tags: string[]; year: number | null }
   >();
 
   try {
@@ -610,6 +612,7 @@ async function buildAnnotationIndex(): Promise<IndexedEntry[]> {
           parentMeta = {
             title: getItemTitleSafe(parentItem) || "",
             authors: getItemAuthorsSafe(parentItem) || "",
+            tags: getItemTags(parentItem),
             year: getItemYearNumber(parentItem),
           };
           parentMetaCache.set(parentItemID, parentMeta);
@@ -629,7 +632,7 @@ async function buildAnnotationIndex(): Promise<IndexedEntry[]> {
           title,
           subtitle,
           authors: parentMeta.authors,
-          tags: [],
+          tags: parentMeta.tags,
           abstractSnippet: annotationComment.slice(0, 120),
           year: parentMeta.year,
           libraryID: getItemLibraryID(attachmentItem, parentItem),
@@ -843,6 +846,7 @@ function parseStructuredQuery(rawQuery: string): ParsedQuery {
   const textTokens: string[] = [];
   const types = new Set<ResultType>();
   const tags: string[] = [];
+  let readingQueue = false;
   let yearMin: number | undefined;
   let yearMax: number | undefined;
 
@@ -864,6 +868,10 @@ function parseStructuredQuery(rawQuery: string): ParsedQuery {
       continue;
     }
     if (token.startsWith(":") && token.length > 1) {
+      if (lower === ":queue") {
+        readingQueue = true;
+        continue;
+      }
       const parsedTypes = parseTypeFilter(token.slice(1));
       parsedTypes.forEach((type) => types.add(type));
       continue;
@@ -898,6 +906,7 @@ function parseStructuredQuery(rawQuery: string): ParsedQuery {
     filters: {
       types,
       tags,
+      readingQueue,
       yearMin,
       yearMax,
     },
@@ -1060,6 +1069,12 @@ function matchesFilters(
         return false;
       }
     }
+  }
+  if (
+    filters.readingQueue &&
+    !entry.tags.includes(NORMALIZED_READING_QUEUE_TAG)
+  ) {
+    return false;
   }
   if (typeof filters.yearMin === "number") {
     if (entry.year === null || entry.year < filters.yearMin) {

--- a/test/readingQueue.test.ts
+++ b/test/readingQueue.test.ts
@@ -1,0 +1,74 @@
+import { assert } from "chai";
+import {
+  getReadingQueueTarget,
+  isInReadingQueue,
+  READING_QUEUE_TAG,
+  setReadingQueueState,
+} from "../src/modules/spotlight/readingQueue";
+
+type FakeItem = {
+  id: number;
+  tags: Array<{ tag: string }>;
+  addTagCalls: string[];
+  removeTagCalls: string[];
+  saveCalls: number;
+  isRegularItem: () => boolean;
+  getTags: () => Array<{ tag: string }>;
+  addTag: (tag: string) => void;
+  removeTag: (tag: string) => void;
+  saveTx: () => Promise<void>;
+};
+
+function createItem(tags: string[] = []): FakeItem {
+  const item: FakeItem = {
+    id: 1,
+    tags: tags.map((tag) => ({ tag })),
+    addTagCalls: [],
+    removeTagCalls: [],
+    saveCalls: 0,
+    isRegularItem: () => true,
+    getTags: () => item.tags,
+    addTag: (tag) => {
+      item.addTagCalls.push(tag);
+      item.tags.push({ tag });
+    },
+    removeTag: (tag) => {
+      item.removeTagCalls.push(tag);
+      item.tags = item.tags.filter((entry) => entry.tag !== tag);
+    },
+    saveTx: async () => {
+      item.saveCalls += 1;
+    },
+  };
+  return item;
+}
+
+describe("reading queue", function () {
+  it("recognizes the portable queue tag case-insensitively", function () {
+    const item = createItem([READING_QUEUE_TAG.toUpperCase()]);
+
+    assert.equal(getReadingQueueTarget(item as Zotero.Item), item);
+    assert.isTrue(isInReadingQueue(item as Zotero.Item));
+  });
+
+  it("adds the queue tag and saves the item", async function () {
+    const item = createItem();
+
+    await setReadingQueueState(item as Zotero.Item, true);
+
+    assert.deepEqual(item.addTagCalls, [READING_QUEUE_TAG]);
+    assert.equal(item.saveCalls, 1);
+    assert.isTrue(isInReadingQueue(item as Zotero.Item));
+  });
+
+  it("removes the existing queue tag and saves the item", async function () {
+    const storedTag = READING_QUEUE_TAG.toUpperCase();
+    const item = createItem([storedTag]);
+
+    await setReadingQueueState(item as Zotero.Item, false);
+
+    assert.deepEqual(item.removeTagCalls, [storedTag]);
+    assert.equal(item.saveCalls, 1);
+    assert.isFalse(isInReadingQueue(item as Zotero.Item));
+  });
+});


### PR DESCRIPTION
## Summary

This two-commit stack extends Spotlight from quick retrieval into a more direct research-action workflow.

### Searchable actions and faster keyboard navigation

- open contextual result actions with `Tab`
- filter available actions from a dedicated action search field
- navigate and execute actions entirely from the keyboard
- open the first nine visible results with `Ctrl+1` through `Ctrl+9`
- update the shortcut guide and accessibility labels

### Synced reading queue

- add or remove papers from a reading queue through commands or contextual actions
- filter queued material with composable `:queue` searches
- show queue badges and filter hints in the palette
- store queue membership as a normal Zotero tag so it remains portable and syncs without another service
- support active papers from the main window, reader, and note editor
- add focused reading-queue tests and documentation

## Why

Spotlight already made sources fast to retrieve. This change makes the next action equally direct and adds a lightweight way to move papers from discovery to deliberate reading.

## Validation

- `npm run lint:check`
- `npm run build`
- `npm test` — 4 tests passed