### PR TITLE
fix: supports Zotero 10, fixes #39

### DIFF
--- a/src/modules/spotlight/palette.ts
+++ b/src/modules/spotlight/palette.ts
@@ -224,7 +224,10 @@ export class PaletteUI {
         (this.win as any).ZoteroPane ||
         Zotero.getMainWindow()?.ZoteroPane ||
         (Zotero.getActiveZoteroPane?.() as any);
-      const col = pane?.getSelectedCollection?.();
+      const col =
+        typeof pane?.getSelectedCollections === "function"
+          ? pane.getSelectedCollections()[0]
+          : pane.getSelectedCollection();
       if (col) {
         this._activeCollection = col;
         const label = this.root.querySelector(

--- a/src/modules/spotlight/palette.ts
+++ b/src/modules/spotlight/palette.ts
@@ -227,7 +227,7 @@ export class PaletteUI {
       const col =
         typeof pane?.getSelectedCollections === "function"
           ? pane.getSelectedCollections()[0]
-          : pane.getSelectedCollection();
+          : pane?.getSelectedCollection?.();
       if (col) {
         this._activeCollection = col;
         const label = this.root.querySelector(
@@ -243,6 +243,7 @@ export class PaletteUI {
       }
     } catch (_) {
       if (this.collectionBar) this.collectionBar.style.display = "none";
+      if (this.collectionCheckbox) this.collectionCheckbox.checked = false;
     }
     this.renderResults();
     void this.updateResults(shouldRestore ? this._savedQuery : "").then(() => {

--- a/src/modules/spotlight/search.ts
+++ b/src/modules/spotlight/search.ts
@@ -309,7 +309,10 @@ export class SearchService {
     const mainPane = Zotero.getMainWindow()?.ZoteroPane;
     const activePane =
       localPane || mainPane || (Zotero.getActiveZoteroPane?.() as any);
-    const selectedLibraryID = activePane?.getSelectedLibraryID?.();
+    const selectedLibraryID =
+      typeof activePane?.getSelectedLibraryIDs === "function"
+        ? activePane.getSelectedLibraryIDs()[0]
+        : activePane?.getSelectedLibraryID?.();
     return typeof selectedLibraryID === "number" ? selectedLibraryID : null;
   }
 


### PR DESCRIPTION
## What changed

- use ZoteroPane.getSelectedLibraryIDs() and ZoteroPane.getSelectedCollections() for Zotero 10

## Why

- fixes #39 

## How to test

- [x] `npm run lint:check`
- [x] `npm run build`
- [ ] `npm run test` (if relevant)
- [x] Tested in Zotero locally (if relevant)

## Notes

- Screenshots or GIFs for UI changes, if helpful
- Linked issue: #39
